### PR TITLE
nix: general cleanup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "hjem": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1735415443,
+        "narHash": "sha256-t/OSIIGVflXP70kQieq72x+zhLVYfMejRopPgOZnV0s=",
+        "owner": "feel-co",
+        "repo": "hjem",
+        "rev": "2979f66c4a1e6f662e4cb7fa9e20b9a6609919f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "feel-co",
+        "repo": "hjem",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735471104,
+        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "hjem": "hjem",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   description = "A module collection for hjem.";
-  
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
@@ -12,12 +12,17 @@
 
   outputs = {
     self,
-    #nixpkgs,
+    nixpkgs,
     ...
-  }: {
+  }: let
+    forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"];
+  in {
     nixosModules = {
       hjem-rum = import ./modules/nixos.nix;
       default = self.nixosModules.hjem-rum;
     };
+
+    # Provide the default formatter to invoke on 'nix fmt'.
+    formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"];
   in {
     nixosModules = {
-      hjem-rum = import ./modules/nixos.nix;
+      hjem-rum = ./modules/nixos.nix;
       default = self.nixosModules.hjem-rum;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A module collection for hjem.";
+  description = "A module collection for Hjem";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,5 +1,4 @@
-{...}: let
-in {
+{
   config = {
     # Import the hjem-rum module collection as an extraModule passed into `hjem.users.<username>`
     # This allows the definition of rum modules under `hjem.users.<username>.rum`

--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -4,9 +4,9 @@
   pkgs,
   ...
 }: let
-  inherit (lib) mkEnableOption mkIf;
-  inherit (lib.options) mkOption literalExpression;
-  inherit (lib.types) package attrs;
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
+  inherit (lib.types) attrsOf anything;
 
   toTOML = (pkgs.formats.toml {}).generate;
 
@@ -15,27 +15,25 @@ in {
   options.rum.programs.alacritty = {
     enable = mkEnableOption "Alacritty";
 
-    package = mkOption {
-      type = package;
-      default = pkgs.alacritty;
-      description = "The nix package to be installed.";
-    };
+    package = mkPackageOption pkgs "alacritty" {};
 
     settings = mkOption {
-      type = attrs;
+      type = attrsOf anything;
       default = {};
-      example = literalExpression ''
+      example = {
         window = {
           dimensions = {
             lines = 28;
             columns = 101;
           };
+
           padding = {
             x = 6;
             y = 3;
           };
         };
-      '';
+      };
+
       description = ''
         The configuration converted into TOML and written to
         `${config.directory}/.config/alacritty/alacritty.toml`.
@@ -46,7 +44,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    packages = [ cfg.package ];
+    packages = [cfg.package];
     files.".config/alacritty/alacritty.toml".source = toTOML "alacritty.toml" cfg.settings;
   };
 }

--- a/modules/programs/default.nix
+++ b/modules/programs/default.nix
@@ -1,6 +1,6 @@
-{...}: {
+{
   # if you have a better way to do this, feel free to PR
   imports = [
     ./alacritty.nix
-  ]; 
+  ];
 }


### PR DESCRIPTION
I think we have a decent base to work with here. It would be very nice to add tests for each module in the future, but I'm not going to bother with those for a year (hah.)

Quick PR to get rid of some footguns ([don't import NixOS modules](https://fzakaria.com/2024/07/29/import-but-don-t-import-your-nixos-modules.html)] and the lack of a vendored flake.lock as well as to organize lib inherits, and remove redundant expressions.