### PR TITLE
Init lib extending

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,11 +16,14 @@
     ...
   }: let
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"];
+    extendedLib = nixpkgs.lib.extend (final: prev: import ./modules/lib/default.nix {lib = prev;});
   in {
     nixosModules = {
       hjem-rum = import ./modules/nixos.nix {inherit (nixpkgs) lib;};
       default = self.nixosModules.hjem-rum;
     };
+
+    specialArgs = {lib = extendedLib;};
 
     # Provide the default formatter to invoke on 'nix fmt'.
     formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.alejandra);

--- a/flake.nix
+++ b/flake.nix
@@ -19,11 +19,11 @@
     extendedLib = nixpkgs.lib.extend (final: prev: import ./modules/lib/default.nix {lib = prev;});
   in {
     nixosModules = {
-      hjem-rum = import ./modules/nixos.nix {inherit (nixpkgs) lib;};
+      hjem-rum = import ./modules/nixos.nix {lib = extendedLib;};
       default = self.nixosModules.hjem-rum;
     };
 
-    specialArgs = {lib = extendedLib;};
+    lib = extendedLib;
 
     # Provide the default formatter to invoke on 'nix fmt'.
     formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.alejandra);

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -1,0 +1,7 @@
+{lib}: {
+  # lib is extended under lib.rum due to annoyances with lib extensions
+  # and also to maximize transparency of what is and isn't custom
+  rum = {
+    generators = import ./generators.nix {inherit lib;};
+  };
+}

--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -1,0 +1,5 @@
+{lib}: {
+  # generatorName = {...}: {
+  #   function
+  # };
+}


### PR DESCRIPTION
Inits the skeleton for extending lib. Doesn't yet add any custom functions, but this allows for contributors to easily extend lib for modules.

- [x] Ran `nix fmt`

@PolarFill, go ahead and add any functions you need. I would prefer to merge this with at least one function added and used as a proof-of-concept.