### PR TITLE
nixosModules: autogenerate list of modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"];
   in {
     nixosModules = {
-      hjem-rum = ./modules/nixos.nix;
+      hjem-rum = import ./modules/nixos.nix {inherit (nixpkgs) lib;};
       default = self.nixosModules.hjem-rum;
     };
 

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,19 +1,12 @@
 {lib}: let
-  inherit (lib.attrsets) filterAttrs attrNames;
-  inherit (lib.trivial) pipe;
-  inherit (builtins) readDir;
+  inherit (lib.filesystem) listFilesRecursive;
 in {
   config = {
     # Import the hjem-rum module collection as an extraModule passed into `hjem.users.<username>`
     # This allows the definition of rum modules under `hjem.users.<username>.rum`
     hjem.extraModules = [
       {
-        imports = pipe ./programs [
-          readDir
-          (filterAttrs (_: v: v == "regular"))
-          attrNames
-          (map (n: ./programs/${n}))
-        ];
+        imports = listFilesRecursive ./programs;
       }
     ];
   };

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,13 +1,17 @@
-{lib}: {
+{lib}: let
+  inherit (lib.attrsets) filterAttrs attrNames;
+  inherit (lib.trivial) pipe;
+  inherit (builtins) readDir;
+in {
   config = {
     # Import the hjem-rum module collection as an extraModule passed into `hjem.users.<username>`
     # This allows the definition of rum modules under `hjem.users.<username>.rum`
     hjem.extraModules = [
       {
-        imports = lib.pipe ./programs [
-          builtins.readDir
-          (lib.filterAttrs (_: v: v == "regular"))
-          lib.attrNames
+        imports = pipe ./programs [
+          readDir
+          (filterAttrs (_: v: v == "regular"))
+          attrNames
           (map (n: ./programs/${n}))
         ];
       }

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,10 +1,15 @@
-{
+{lib}: {
   config = {
     # Import the hjem-rum module collection as an extraModule passed into `hjem.users.<username>`
     # This allows the definition of rum modules under `hjem.users.<username>.rum`
     hjem.extraModules = [
       {
-        imports = [./programs];
+        imports = lib.pipe ./programs [
+          builtins.readDir
+          (lib.filterAttrs (_: v: v == "regular"))
+          lib.attrNames
+          (map (n: ./programs/${n}))
+        ];
       }
     ];
   };

--- a/modules/programs/default.nix
+++ b/modules/programs/default.nix
@@ -1,9 +1,0 @@
-{
-  # if you have a better way to do this, feel free to PR
-  imports = [
-    ./alacritty.nix
-    ./obs-studio.nix
-    ./spotify-player.nix
-    ./vscode.nix
-  ];
-}


### PR DESCRIPTION
Created a function that creates a list of all the modules inside the programs folder. If other folders are used in the future, this function can be easily modified to be applied to each folder by mapping it.

Basically, this function reads the directory, filters all files that are "regular", picks their names (paths) and puts the parent directory in the path. When/if the pipe operator becomes stable we can use it instead of lib.pipe, making it cleaner.

Removed the programs/default.nix, as it isn't necessary anymore. Also, modified the module call in flake.nix to handle a function that receives a lib argument, as nixpkgs' lib is necessary.