### PR TITLE
add ncmpcpp module

### DIFF
--- a/modules/collection/programs/ncmpcpp.nix
+++ b/modules/collection/programs/ncmpcpp.nix
@@ -1,0 +1,74 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
+  inherit (lib.types) attrsOf listOf oneOf int str bool;
+  inherit (lib.rum.generators.ncmpcpp) toNcmpcppBinding toNcmpcppSettings;
+  inherit (lib.rum.types) ncmpcppBindingType;
+
+  cfg = config.rum.programs.ncmpcpp;
+in {
+  options.rum.programs.ncmpcpp = {
+    enable = mkEnableOption ''
+      Enables the rum module for ncmpcpp, a mpd-based music player.
+    '';
+
+    package = mkPackageOption pkgs "ncmpcpp" {
+      extraDescription = ''
+	You can use an override to toggle certain features like the visualizer, a clock screen, and more.
+        Please check out the package source for a complete list.
+      '';
+    };
+
+    settings = mkOption {
+      type = attrsOf (oneOf [int str bool]);
+      default = {};
+      example = {
+	mpd_host = "localhost";
+	mpd_port = 6600;
+	mpd_music_dir = "~/music";
+	statusbar_visibility = true;
+      };
+      description = ''
+        Configuration written to `${config.directory}/.config/ncmpcpp/config`.
+        Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access
+        https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/config for an example.
+      '';
+    };
+
+    bindings = mkOption {
+      type = attrsOf (listOf ncmpcppBindingType);
+      default = {};
+      description = ''
+        Custom bindings configuration written to `${config.directory}/.config/ncmpcpp/bindings`.
+        Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access
+        https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/bindings for an example.
+
+	The lists are separated between keys, for actions ran on keypresses, and commands, for
+	actions ran on commands. The option's example demonstrates this greatly.
+      '';
+      example = {
+        keys = [
+	  {binding = "ctrl-q"; actions = ["stop" "quit"];}
+	  {binding = "q"; actions = ["quit"]; deferred = true;}
+	];
+	commands = [
+	  {binding = "!sq"; actions = ["stop" "quit"];}
+	  {binding = "!q"; actions = ["quit"]; deferred = true;}
+	];
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    packages = [cfg.package];
+    files = {
+      ".config/ncmpcpp/config".text = mkIf (cfg.settings != {}) (toNcmpcppSettings cfg.settings);
+      ".config/ncmpcpp/bindings".text = mkIf (cfg.bindings != {}) (toNcmpcppBinding cfg.bindings);
+    };
+  };
+}

--- a/modules/lib/generators/default.nix
+++ b/modules/lib/generators/default.nix
@@ -1,3 +1,4 @@
 {lib}: {
   gtk = import ./gtk.nix {inherit lib;};
+  ncmpcpp = import ./ncmpcpp.nix {inherit lib;};
 }

--- a/modules/lib/generators/ncmpcpp.nix
+++ b/modules/lib/generators/ncmpcpp.nix
@@ -1,0 +1,45 @@
+{lib}: let
+  inherit (builtins) toString typeOf map concatStringsSep;
+  inherit (lib.attrsets) mapAttrsToList;
+in {
+  toNcmpcppBinding = settings: let
+    genSubmodule = suffix: submodule:
+      concatStringsSep "\n" (map (
+          attrset: ''
+            def_${suffix} "${attrset.binding}" [${
+              if attrset.deferred == true
+              then "deferred"
+              else "immediate"
+            }]
+              ${concatStringsSep "\n" attrset.actions}
+          ''
+        )
+        submodule);
+  in ''
+    ${
+      if (settings ? keys)
+      then (genSubmodule "key" settings.keys)
+      else ""
+    }
+    ${
+      if (settings ? commands)
+      then (genSubmodule "command" settings.commands)
+      else ""
+    }
+  '';
+
+  toNcmpcppSettings = settings: let
+    convertValue = value:
+      {
+        string = value;
+        int = toString value;
+        path = toString value;
+        bool =
+          if value
+          then "yes"
+          else "no";
+      }
+      .${typeOf value};
+  in
+    concatStringsSep "\n" (mapAttrsToList (name: value: "${name} = ${convertValue value}") settings);
+}

--- a/modules/lib/types/default.nix
+++ b/modules/lib/types/default.nix
@@ -1,3 +1,4 @@
 {lib}: {
   gtkType = import ./gtkType.nix {inherit lib;};
+  ncmpcppBindingType = import ./ncmpcppBindingType.nix {inherit lib;};
 }

--- a/modules/lib/types/ncmpcppBindingType.nix
+++ b/modules/lib/types/ncmpcppBindingType.nix
@@ -1,0 +1,39 @@
+{lib}: let
+  inherit (lib.types) nullOr listOf bool str submodule;
+  inherit (lib.options) mkOption;
+in ( 
+  submodule {
+    options = {
+      binding = mkOption {
+        type = nullOr str;
+        default = null;
+        description = ''
+          The key or command for which the set of actions is binded to.
+        '';
+        example = "p";
+        apply = x:
+          assert (!isNull x
+            || ''
+              A binding for ncmpcpp wasn't properly defined, as it's missing the key or command its binded to.
+              You need to specify a key or a command which'll run the specified actions.
+            ''); x;
+      };
+      actions = mkOption {
+        type = nullOr (listOf str);
+        default = null;
+        description = ''
+          The actions to be ran on either the key's or command's activation.
+        '';
+        example = ["stop" "quit"];
+      };
+      deferred = mkOption {
+        type = bool;
+        default = false;
+        description = ''
+          Whether the binding or command should be deferred (true) or immediate (false).
+        '';
+        example = true;
+      };
+    };
+  }
+)


### PR DESCRIPTION
Adds support for [ncmpcpp](https://github.com/ncmpcpp/ncmpcpp/) configuration via rum.

Currently, the bindings interface accepts lines instead of trying to convert an attrset, but an approach similar to the [hm module](https://github.com/nix-community/home-manager/blob/release-24.05/modules/programs/ncmpcpp.nix#L21) could be taken.