### PR TITLE
collection: add logic for file generation only if not null

### DIFF
--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -44,6 +44,8 @@ in {
 
   config = mkIf cfg.enable {
     packages = [cfg.package];
-    files.".config/alacritty/alacritty.toml".source = toml.generate "alacritty.toml" cfg.settings;
+    files.".config/alacritty/alacritty.toml".source = mkIf (cfg.settings != {}) (
+      toml.generate "alacritty.toml" cfg.settings
+    );
   };
 }

--- a/modules/programs/spotify-player.nix
+++ b/modules/programs/spotify-player.nix
@@ -116,9 +116,18 @@ in {
   config = mkIf cfg.enable {
     packages = [cfg.package];
     files = {
-      ".config/spotify-player/app.toml".source = toml.generate "spotify-player/app.toml" cfg.settings;
-      ".config/spotify-player/theme.toml".source = toml.generate "spotify-player/theme.toml" {inherit (cfg) themes;}; # Passes each declared theme under the "themes" attr as needed
-      ".config/spotify-player/keymap.toml".source = toml.generate "spotify-player/keymap.toml" cfg.keymap;
+      ".config/spotify-player/app.toml".source = mkIf (cfg.settings != {}) (
+        toml.generate "spotify-player/app.toml" cfg.settings
+      );
+
+      # Passes each declared theme under the "themes" attr as needed
+      ".config/spotify-player/theme.toml".source = mkIf (cfg.themes != []) (
+        toml.generate "spotify-player/theme.toml" {inherit (cfg) themes;}
+      );
+
+      ".config/spotify-player/keymap.toml".source = mkIf (cfg.keymap != {}) (
+        toml.generate "spotify-player/keymap.toml" cfg.keymap
+      );
     };
   };
 }

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -38,7 +38,9 @@ in {
   config = mkIf cfg.enable {
     packages = [cfg.package];
     files = {
-      ".config/Code/User/settings.json".text = toJSON cfg.settings;
+      ".config/Code/User/settings.json".text = mkIf (cfg.settings != {}) (
+        toJSON cfg.settings
+      );
     };
   };
 }


### PR DESCRIPTION
This simple PR adds conditional logic to file generation so that they are only created and symlinked if the config has actually been changed.

In practice, this means there won't be empty files cluttering the store, and that a user does not need a `mkDefault` to change a file themself when using a certain module; i.e. if I am using the spotify-player module but wish to link `theme.toml` to a specific file, I can doso without the use of `mkDefault`.

- [x] Ran `nix fmt`
