### PR TITLE
nixos: properly pass the extended library into extraModules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735415443,
-        "narHash": "sha256-t/OSIIGVflXP70kQieq72x+zhLVYfMejRopPgOZnV0s=",
+        "lastModified": 1739891453,
+        "narHash": "sha256-dnJMqM3SVKSOOaRZOLDaRckFRHKInvwM9kqrOlS16VU=",
         "owner": "feel-co",
         "repo": "hjem",
-        "rev": "2979f66c4a1e6f662e4cb7fa9e20b9a6609919f9",
+        "rev": "f57c3210c08815cb141de3e49383a020d37ed36c",
         "type": "github"
       },
       "original": {

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -4,10 +4,13 @@ in {
   config = {
     # Import the hjem-rum module collection as an extraModule passed into `hjem.users.<username>`
     # This allows the definition of rum modules under `hjem.users.<username>.rum`
-    hjem.extraModules = [
-      {
-        imports = listFilesRecursive ./collection;
-      }
-    ];
+    hjem = {
+      extraModules = [
+        {
+          imports = listFilesRecursive ./collection;
+        }
+      ];
+      specialArgs = {inherit lib;};
+    };
   };
 }


### PR DESCRIPTION
The extended library was previously not properly being imported into the extraModules due to the way it is setup. It is now properly passed through Hjem's `specialArgs` option and now is made available in modules.

- [x] Ran `nix fmt`

@PolarFill if you can, try to rebase onto this PR to test it out.