### PR TITLE
hyprland: init module

### DIFF
--- a/modules/lib/attrsets/default.nix
+++ b/modules/lib/attrsets/default.nix
@@ -1,0 +1,3 @@
+{lib}: {
+  filterKeysPrefixes = import ./filterKeysPrefixes.nix {inherit lib;};
+}

--- a/modules/lib/attrsets/filterKeysPrefixes.nix
+++ b/modules/lib/attrsets/filterKeysPrefixes.nix
@@ -1,0 +1,28 @@
+{lib}: let
+  inherit (builtins) any;
+  inherit (lib.attrsets) filterAttrs;
+  inherit (lib.strings) hasPrefix;
+in
+  /*
+  Filters an attribute set with prefixes applied to keys.
+
+  # Inputs
+
+  `prefixes`
+
+  : A list of prefixes to filter the attribute set with.
+
+  `attrs`
+
+  : The attribute set to apply the filter on.
+
+  Value
+  : The filtered attribute set.
+  */
+  prefixes: attrs:
+    if prefixes == []
+    then attrs
+    else
+      filterAttrs
+      (name: _: any (prefix: hasPrefix prefix name) prefixes)
+      attrs

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -3,7 +3,6 @@
   # and also to maximize transparency of what is and isn't custom
   rum = {
     generators = import ./generators {inherit lib;};
-
     types = import ./types {inherit lib;};
   };
 }

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -2,6 +2,7 @@
   # lib is extended under lib.rum due to annoyances with lib extensions
   # and also to maximize transparency of what is and isn't custom
   rum = {
+    attrsets = import ./attrsets {inherit lib;};
     generators = import ./generators {inherit lib;};
     types = import ./types {inherit lib;};
   };

--- a/modules/lib/generators/default.nix
+++ b/modules/lib/generators/default.nix
@@ -1,4 +1,5 @@
 {lib}: {
   gtk = import ./gtk.nix {inherit lib;};
   ncmpcpp = import ./ncmpcpp.nix {inherit lib;};
+  hypr = import ./hypr.nix {inherit lib;};
 }

--- a/modules/lib/generators/default.nix
+++ b/modules/lib/generators/default.nix
@@ -1,5 +1,6 @@
 {lib}: {
+  environment = import ./environment.nix {inherit lib;};
   gtk = import ./gtk.nix {inherit lib;};
-  ncmpcpp = import ./ncmpcpp.nix {inherit lib;};
   hypr = import ./hypr.nix {inherit lib;};
+  ncmpcpp = import ./ncmpcpp.nix {inherit lib;};
 }

--- a/modules/lib/generators/environment.nix
+++ b/modules/lib/generators/environment.nix
@@ -1,0 +1,17 @@
+{lib}: let
+  inherit (builtins) map isList toString;
+  inherit (lib.attrsets) mapAttrsToList;
+  inherit (lib.strings) concatStringsSep;
+
+  toEnvValue = env:
+    if isList env
+    then concatStringsSep ":" (map toString env)
+    else toString env;
+
+  toEnvExport = vars: (concatStringsSep "\n"
+    (mapAttrsToList
+      (name: value: "export ${name}=\"${toEnvValue value}\"")
+      vars));
+in {
+  inherit toEnvExport toEnvValue;
+}

--- a/modules/lib/generators/hypr.nix
+++ b/modules/lib/generators/hypr.nix
@@ -1,0 +1,71 @@
+# basically 1:1 taken from https://github.com/nix-community/home-manager/blob/master/modules/services/window-managers/hyprland.nix
+{lib}: let
+  toHyprconf = {
+    attrs,
+    indentLevel ? 0,
+    importantPrefixes ? ["$"],
+  }: let
+    inherit (builtins) all isAttrs isList removeAttrs;
+    inherit (lib.attrsets) filterAttrs mapAttrsToList;
+    inherit (lib.generators) toKeyValue;
+    inherit (lib.lists) foldl replicate;
+    inherit (lib.strings) concatStrings concatStringsSep concatMapStringsSep hasPrefix;
+
+    initialIndent = concatStrings (replicate indentLevel "  ");
+
+    toHyprconf' = indent: attrs: let
+      sections =
+        filterAttrs (_: v: isAttrs v || (isList v && all isAttrs v)) attrs;
+
+      mkSection = n: attrs:
+        if lib.isList attrs
+        then (concatMapStringsSep "\n" (a: mkSection n a) attrs)
+        else ''
+          ${indent}${n} {
+          ${toHyprconf' "  ${indent}" attrs}${indent}}
+        '';
+
+      mkFields = toKeyValue {
+        listsAsDuplicateKeys = true;
+        inherit indent;
+      };
+
+      allFields =
+        filterAttrs (_: v: !(isAttrs v || (isList v && all isAttrs v)))
+        attrs;
+
+      isImportantField = n: _:
+        foldl (acc: prev:
+          if hasPrefix prev n
+          then true
+          else acc)
+        false
+        importantPrefixes;
+
+      importantFields = filterAttrs isImportantField allFields;
+
+      fields =
+        removeAttrs allFields
+        (mapAttrsToList (n: _: n) importantFields);
+    in
+      mkFields importantFields
+      + concatStringsSep "\n" (mapAttrsToList mkSection sections)
+      + mkFields fields;
+  in
+    toHyprconf' initialIndent attrs;
+
+  # taken from https://github.com/hyprwm/Hyprland/blob/f4b148df1e2d8edc96bd878a4cfde32ca6515ac8/nix/module.nix#L185-L197
+  pluginsToHyprconf = plugins: importantPrefixes:
+    toHyprconf {
+      attrs = {
+        plugin = let
+          mkEntry = entry:
+            if lib.types.package.check entry
+            then "${entry}/lib/lib${entry.pname}.so"
+            else entry;
+        in
+          map mkEntry plugins;
+      };
+      inherit importantPrefixes;
+    };
+in {inherit toHyprconf pluginsToHyprconf;}

--- a/modules/lib/types/default.nix
+++ b/modules/lib/types/default.nix
@@ -1,5 +1,6 @@
 {lib}: {
   gtkType = import ./gtkType.nix {inherit lib;};
+  hyprType = import ./hyprType.nix {inherit lib;};
   ncmpcppBindingType = import ./ncmpcppBindingType.nix {inherit lib;};
   tofiSettingsType = import ./tofiSettingsType.nix {inherit lib;};
 }

--- a/modules/lib/types/hyprType.nix
+++ b/modules/lib/types/hyprType.nix
@@ -1,0 +1,8 @@
+{lib}: let
+  inherit (lib.types) attrsOf listOf oneOf bool float int path str;
+
+  hyprValue = oneOf [str path bool int float hyprList hyprMap];
+  hyprMap = attrsOf hyprValue;
+  hyprList = listOf hyprValue;
+in
+  hyprMap


### PR DESCRIPTION
This PR adds Hyprland support for hjem-rum. 

# Things done

- Settings mapped to hyprlang
- Plugins (can either take in a path or a package)
- Automatic environment sourcing (using the user's NixOS config to determine whether or not UWSM is enabled and imports environment the proper way)

Note that the latter will need to be added once hjem gets support for environment variables (feel-co/hjem#16), hence the draft status of this PR.