### PR TITLE
nixos.nix: init osConfig specialArg

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,4 +1,4 @@
-{lib}: let
+{lib}: {config, ...}: let
   inherit (lib.filesystem) listFilesRecursive;
 in {
   config = {
@@ -10,7 +10,10 @@ in {
           imports = listFilesRecursive ./collection;
         }
       ];
-      specialArgs = {inherit lib;};
+      specialArgs = {
+        inherit lib;
+        osConfig = config;
+      };
     };
   };
 }


### PR DESCRIPTION
This PR allows module writers to reference the system config with `osConfig`. Basically, all it is is an alias for `config` while the standard `config` is an alias for `config.hjem.users.<username>`.

- [x] Ran `nix fmt`