### PR TITLE
GTK: Cleanup 'attrsHasPrefix' function

### DIFF
--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -7,12 +7,12 @@
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.types) listOf package lines;
   inherit (lib.modules) mkIf;
+  inherit (lib.lists) optionals;
+  inherit (lib.attrsets) optionalAttrs;
   inherit (lib.rum.generators.gtk) toGtk2Text toGtkINI;
   inherit (lib.rum.types) gtkType;
-  inherit (lib.strings) hasPrefix;
-  inherit (lib.lists) optionals any;
-  inherit (lib.attrsets) optionalAttrs;
-  inherit (builtins) attrNames hasAttr;
+  inherit (lib.rum.attrsets) attrNamesHasPrefix;
+  inherit (builtins) hasAttr;
 
   cfg = config.rum.gtk;
 in {
@@ -77,12 +77,9 @@ in {
   config = mkIf cfg.enable {
     # We could also just automatically fix it, but for now, simply
     # check if the user accidentally included a 'gtk-' prefix.
-    warnings = let
-      attrsHasPrefix = prefix: attrs: (any (hasPrefix prefix) (attrNames attrs));
-    in
-      optionals (attrsHasPrefix "gtk-" cfg.settings) [
-        "Each option in 'rum.gtk.settings' is automatically prefixed with 'gtk-' if it is not present already. You have added this to an option unnecessarily."
-      ];
+    warnings = optionals (attrNamesHasPrefix "gtk-" cfg.settings) [
+      "Each option in 'rum.gtk.settings' is automatically prefixed with 'gtk-' if it is not present already. You have added this to an option unnecessarily."
+    ];
 
     inherit (cfg) packages;
 

--- a/modules/lib/attrsets/attrNamesHasPrefix.nix
+++ b/modules/lib/attrsets/attrNamesHasPrefix.nix
@@ -1,0 +1,10 @@
+{lib}: let
+  inherit (lib.strings) hasPrefix;
+  inherit (lib.lists) any;
+  inherit (builtins) attrNames;
+in
+  # Super simple function to check if any attributes' names
+  # in the input attrset contain the input prefix
+  prefix: attrs: (
+    any (hasPrefix prefix) (attrNames attrs)
+  )

--- a/modules/lib/attrsets/default.nix
+++ b/modules/lib/attrsets/default.nix
@@ -1,3 +1,4 @@
 {lib}: {
+  attrNamesHasPrefix = import ./attrNamesHasPrefix.nix {inherit lib;};
   filterKeysPrefixes = import ./filterKeysPrefixes.nix {inherit lib;};
 }


### PR DESCRIPTION
I moved the `attrsHasPrefix` function over into `lib/attrsets` to fit the new structure. I also took the liberty of renaming it to `attrNamesHasPrefix` to more accurately fit what the function does. After all, it literally is just a combination of `attrNames` and `hasPrefix`, so it seems more fitting. Plus, because it only checks the names, this seems more clear.

- [x] Ran `nix fmt`
