### PR TITLE
starship: init module

### DIFF
--- a/modules/collection/programs/starship.nix
+++ b/modules/collection/programs/starship.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkEnableOption mkOption mkPackageOption;
+
+  toml = pkgs.formats.toml {};
+
+  cfg = config.programs.starship;
+in {
+  options.programs.starship = {
+    enable = mkEnableOption "starship module.";
+    package = mkPackageOption pkgs "starship" {};
+    settings = mkOption {
+      type = toml.type;
+      default = {};
+      example = {
+        add_newline = false;
+        format = lib.concatStrings [
+          "$line_break"
+          "$package"
+          "$line_break"
+          "$character"
+        ];
+        scan_timeout = 10;
+        character = {
+          success_symbol = "➜";
+          error_symbol = "➜";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    packages = [cfg.package];
+    files = {
+      ".config/starship.toml".source = mkIf (cfg.settings != {}) (
+        toml.generate "starship.toml" cfg.settings
+      );
+    };
+  };
+}


### PR DESCRIPTION
This PR adds a [Starship](https://starship.rs/) module.  Please keep in mind that shell support will need to be added once we get them into hjr. As per discussing it with @Lunarnovaa, a possible API we could use for it is: 

```nix
# collection/programs/zsh.nix
  options.programs.zsh = {
  # ...
  integrations.starship = mkOption {
    default = programs.starship.enable;
  };
};
```

But this will do for now, since we do not have shells just yet.

- [x] Ran `nix fmt`
- [x] Tested the module locally