### PR TITLE
dconf: init module

### DIFF
--- a/modules/collection/misc/dconf.nix
+++ b/modules/collection/misc/dconf.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  inherit (builtins) toString;
+  inherit (lib.generators) toINI;
+  inherit (lib.gvariant) mkValue;
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.rum.types) gvariantType;
+  inherit (lib.types) attrsOf literalExpression;
+
+  toDconfIni = toINI {mkKeyValue = mkIniKeyValue;};
+  mkIniKeyValue = key: value: "${key}=${toString (mkValue value)}";
+
+  cfg = config.rum.dconf;
+in {
+  options.rum.dconf = {
+    enable = mkEnableOption "dconf module.";
+    settings = mkOption {
+      type = attrsOf (attrsOf gvariantType);
+      default = {};
+      example = literalExpression ''
+        {
+          "org/gnome/calculator" = {
+            button-mode = "programming";
+            show-thousands = true;
+            base = 10;
+            word-size = 64;
+            window-position = lib.gvariant.mkTuple [100 100];
+          };
+        }
+      '';
+      description = ''
+        Settings to write to the dconf configuration system.
+
+        Note that the database is strongly-typed so you need to use the same types
+        as described in the GSettings schema. For example, if an option is of type
+        `uint32` (`u`), you need to wrap the number
+        using the `lib.gvariant.mkUint32` constructor.
+        Otherwise, since Nix integers are implicitly coerced to `int32`
+        (`i`), it would get stored in the database as such, and GSettings
+        might be confused when loading the setting.
+
+        You might want to use [dconf2nix](https://github.com/gvolpe/dconf2nix)
+        to convert dconf database dumps into compatible Nix expression.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.load-dconf = let
+      iniFile = pkgs.writeText "dconf.ini" (toDconfIni cfg.settings);
+      loadDconf = pkgs.writeShellScript "dconf-load" ''
+        if [[ -v DBUS_SESSION_BUS_ADDRESS ]]; then
+                export DCONF_DBUS_RUN_SESSION=""
+              else
+                export DCONF_DBUS_RUN_SESSION="${pkgs.dbus}/bin/dbus-run-session --dbus-daemon=${pkgs.dbus}/bin/dbus-daemon"
+              fi
+
+        $DCONF_DBUS_RUN_SESSION ${pkgs.dconf}/bin/dconf reset -f /
+        $DCONF_DBUS_RUN_SESSION ${pkgs.dconf}/bin/dconf load / < ${iniFile}
+
+        unset DCONF_DBUS_RUN_SESSION
+      '';
+    in {
+      wantedBy = ["multi-user.target"];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = loadDconf;
+      };
+    };
+  };
+}

--- a/modules/lib/types/default.nix
+++ b/modules/lib/types/default.nix
@@ -1,5 +1,6 @@
 {lib}: {
   gtkType = import ./gtkType.nix {inherit lib;};
+  gvariantType = import ./gvariantType.nix {inherit lib;};
   hyprType = import ./hyprType.nix {inherit lib;};
   ncmpcppBindingType = import ./ncmpcppBindingType.nix {inherit lib;};
   tofiSettingsType = import ./tofiSettingsType.nix {inherit lib;};

--- a/modules/lib/types/gvariantType.nix
+++ b/modules/lib/types/gvariantType.nix
@@ -1,0 +1,85 @@
+# taken from https://github.com/nix-community/home-manager/blob/fcac3d6d88302a5e64f6cb8014ac785e08874c8d/modules/lib/gvariant.nix
+# A partial and basic implementation of GVariant formatted strings.
+#
+# Note, this API is not considered fully stable and it might therefore
+# change in backwards incompatible ways without prior notice.
+{lib}: let
+  inherit (builtins) all head;
+  inherit (lib) throw;
+  inherit (lib.gvariant) isGVariant mkValue;
+  inherit (lib.lists) foldl';
+  inherit (lib.options) getFiles mergeDefaultOption mergeOneOption showFiles showOption;
+  inherit (lib.strings) hasPrefix;
+  inherit (lib.types) float listOf str;
+
+  type = {
+    string = "s";
+    boolean = "b";
+    uchar = "y";
+    int16 = "n";
+    uint16 = "q";
+    int32 = "i";
+    uint32 = "u";
+    int64 = "x";
+    uint64 = "t";
+    double = "d";
+    variant = "v";
+  };
+
+  isArray = hasPrefix "a";
+  isDictionaryEntry = hasPrefix "{";
+  isMaybe = hasPrefix "m";
+  isTuple = hasPrefix "(";
+
+  gvariant = lib.mkOptionType rec {
+    name = "gvariant";
+    description = "GVariant value";
+    check = v: mkValue v != null;
+    merge = loc: defs: let
+      vdefs = map (d:
+        d
+        // {
+          value =
+            if isGVariant d.value
+            then d.value
+            else mkValue d.value;
+        })
+      defs;
+      vals = map (d: d.value) vdefs;
+      defTypes = map (x: x.type) vals;
+      sameOrNull = x: y:
+        if x == y
+        then y
+        else null;
+      # A bit naive to just check the first entry…
+      sharedDefType = foldl' sameOrNull (head defTypes) defTypes;
+      allChecked = all (x: check x) vals;
+    in
+      if sharedDefType == null
+      then
+        throw ("Cannot merge definitions of `${showOption loc}' with"
+          + " mismatched GVariant types given in"
+          + " ${showFiles (getFiles defs)}.")
+      else if isArray sharedDefType && allChecked
+      then
+        mkValue ((listOf gvariant).merge loc
+          (map (d: d // {value = d.value.value;}) vdefs))
+        // {
+          type = sharedDefType;
+        }
+      else if isTuple sharedDefType && allChecked
+      then mergeOneOption loc defs
+      else if isMaybe sharedDefType && allChecked
+      then mergeOneOption loc defs
+      else if isDictionaryEntry sharedDefType && allChecked
+      then mergeOneOption loc defs
+      else if type.variant == sharedDefType && allChecked
+      then mergeOneOption loc defs
+      else if type.string == sharedDefType && allChecked
+      then str.merge loc defs
+      else if type.double == sharedDefType && allChecked
+      then float.merge loc defs
+      else mergeDefaultOption loc defs;
+  };
+in
+  gvariant


### PR DESCRIPTION
This is a draft PR for dconf databases management at home level. A lot of the logic has been copied from home-manager (the [gvariant internals](https://github.com/nix-community/home-manager/blob/fcac3d6d88302a5e64f6cb8014ac785e08874c8d/modules/lib/gvariant.nix) and the [dconf module](https://github.com/nix-community/home-manager/blob/fcac3d6d88302a5e64f6cb8014ac785e08874c8d/modules/misc/dconf.nix)). 

The draft status is mostly warranted by the fact that this would require some sort of way of automatically loading the dconf configuration after rebuilding the system, which requires systemd services to be upstreamed in Hjem (track feel-co/hjem#18).

This is in no way feature complete, as it misses a mechanism to cleanup old dconf keys, which would need some sort of diff (I was thinking of creating a derivation containing a json file, akin to what home-manager does, which would be symlinked at something like `$XDG_CONFIG_HOME/dconf/.previous-state` or similar).