### PR TITLE
modules/collection: migrate modules to `pkgs.formats`

### DIFF
--- a/modules/collection/programs/vscode.nix
+++ b/modules/collection/programs/vscode.nix
@@ -6,8 +6,8 @@
 }: let
   inherit (lib.modules) mkIf;
   inherit (lib.options) mkOption mkEnableOption mkPackageOption;
-  inherit (lib.types) attrsOf anything;
-  inherit (builtins) toJSON;
+
+  json = pkgs.formats.json {};
 
   cfg = config.rum.programs.vscode;
 in {
@@ -17,7 +17,7 @@ in {
     package = mkPackageOption pkgs "vscode" {};
 
     settings = mkOption {
-      type = attrsOf anything;
+      type = json.type;
       default = {};
       example = {
         "editor.fontFamily" = "Fira Code Nerdfont";
@@ -38,8 +38,8 @@ in {
   config = mkIf cfg.enable {
     packages = [cfg.package];
     files = {
-      ".config/Code/User/settings.json".text = mkIf (cfg.settings != {}) (
-        toJSON cfg.settings
+      ".config/Code/User/settings.json".source = mkIf (cfg.settings != {}) (
+        json.generate "settings.json" cfg.settings
       );
     };
   };


### PR DESCRIPTION
This PR brings the ghostty and vscode module to be more in line with the others, i.e. use `pkgs.formats` generators instead, which provide a very convenient type as well as a generate function, which we can directly set as the file source.

Please keep in mind that this brings slightly breaking changes for ghostty, as keybinds cannot be defined like this anymore:

```nix
              keybind = {
                "${prefix}>c" = "new_tab";
                "${prefix}>p" = "move_tab:-1";
                "${prefix}>n" = "move_tab:1";
              };
```

But instead have to be defined as such (akin to home-manager): 

```nix
              keybind = [
                "${prefix}>c=new_tab"
                "${prefix}>p=move_tab:-1"
                "${prefix}>n=move_tab:1"
              ];
```
This will be the case for every nested key-value pairs.

PS: @Lunarnovaa since I do not use VSCode, could you please test it to see if it works as expected? It shouldn't be an issue, but I'd like to make sure regardless. 