### PR TITLE
Add support for tests

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,38 @@
+Hjem-rum's testing system is designed with simplicity in mind, so we shy away from other testing frameworks and stick with ``runTest``, from the [internal nixos lib](https://github.com/NixOS/nixpkgs/tree/master/nixos/lib/testing) located in the nixpkgs monorepo. There are no non-standard abstractions in regards to writing the tests, so they should be written just like any other test that uses the NixOS Test Driver.
+
+
+## Creating tests
+
+Every file is automatically imported with ``lib.filesystem.listFilesRecursive``, given that there is a check output that imports the directory (more on that later), so your only worry should be creating the tests in their relevant directories. If you're writing a test for btop, for instance, you should create a module under /modules/tests/programs, and probably name it after the program you're testing (so btop.nix).
+
+If you're certain your test category doesn't get covered by any of the existing directories, you can create a new one together with a check that imports files in this directory. This is really easy to do:
+
+``` nix
+checks = { 
+  ...
+  # Just import ./modules/tests and pass mkCheckArgs with your brand-new directory to it.
+  hjem-rum-services = import ./modules/tests (mkCheckArgs ./modules/tests/services);
+};
+```
+
+This can also be used to import and run only individual test modules, although this isn't recommended (you can just build the test and run it yourself) and code doing that shouldn't be commited.
+
+
+## Writing tests
+
+Tests for ``hjem-rum`` are written just like any other test, so it might be worth to take a read at how NixOS tests work. There is [a guide](https://nix.dev/tutorials/nixos/integration-testing-using-virtual-machines.html) in nix.dev and also a [section on the nixos manual](https://nixos.org/manual/nixos/stable/index.html#sec-calling-nixos-tests)¹, both detailing how to use the framework.
+
+Our test system has some pre-defined things aiming at avoid boilerplate code:
+
+- An user named "bob" is already created², with no groups, ``isNormalUser`` set to true and no password.
+- ``hjem`` and ``hjem-rum`` are already imported by default.
+
+``self``, ``lib`` and ``pkgs`` are also passed to every test module, so you're free to use them as you will.
+
+The [ncmpcpp test module](../modules/tests/programs/ncmpcpp/ncmpcpp.nix) was written to serve as an example for future tests, and provides comments for each step of the ``testScript``. Care should be taken to wait for the proper systemd targets to be reached, change users to run commands, and avoid other possible footguns. The approach this module uses to test its configuration is to have a file for each configuration alongside it, which then gets passed to the test vm and gets evaluated with diff. You can use other approachs if its more convenient, that's just a suggestion :D.
+
+---
+
+###### ¹ Although both guides refer to ``lib.tests.runNixOSTest`` instead of ``runTest``, the former is just a wrapper around the latter, abstracting certain concepts, so the code ran by them should be interchangeable between one another.
+
+###### ² This is a reference to [Bob and Alice](https://en.wikipedia.org/wiki/Alice_and_Bob), two names that are commonly used as placeholders, and since Hjem went with Alice, we chose Bob ;D.

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,42 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "hjem": {
       "inputs": {
         "nixpkgs": [
@@ -36,10 +73,33 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "hjem": "hjem",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     }
   },

--- a/modules/collection/programs/ncmpcpp.nix
+++ b/modules/collection/programs/ncmpcpp.nix
@@ -19,8 +19,8 @@ in {
 
     package = mkPackageOption pkgs "ncmpcpp" {
       extraDescription = ''
-	You can use an override to toggle certain features like the visualizer, a clock screen, and more.
-        Please check out the package source for a complete list.
+        You can use an override to toggle certain features like the visualizer, a clock screen, and more.
+               Please check out the package source for a complete list.
       '';
     };
 
@@ -28,10 +28,10 @@ in {
       type = attrsOf (oneOf [int str bool]);
       default = {};
       example = {
-	mpd_host = "localhost";
-	mpd_port = 6600;
-	mpd_music_dir = "~/music";
-	statusbar_visibility = true;
+        mpd_host = "localhost";
+        mpd_port = 6600;
+        mpd_music_dir = "~/music";
+        statusbar_visibility = true;
       };
       description = ''
         Configuration written to `${config.directory}/.config/ncmpcpp/config`.
@@ -44,22 +44,36 @@ in {
       type = attrsOf (listOf ncmpcppBindingType);
       default = {};
       description = ''
-        Custom bindings configuration written to `${config.directory}/.config/ncmpcpp/bindings`.
-        Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access
-        https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/bindings for an example.
+               Custom bindings configuration written to `${config.directory}/.config/ncmpcpp/bindings`.
+               Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access
+               https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/bindings for an example.
 
-	The lists are separated between keys, for actions ran on keypresses, and commands, for
-	actions ran on commands. The option's example demonstrates this greatly.
+        The lists are separated between keys, for actions ran on keypresses, and commands, for
+        actions ran on commands. The option's example demonstrates this greatly.
       '';
       example = {
         keys = [
-	  {binding = "ctrl-q"; actions = ["stop" "quit"];}
-	  {binding = "q"; actions = ["quit"]; deferred = true;}
-	];
-	commands = [
-	  {binding = "!sq"; actions = ["stop" "quit"];}
-	  {binding = "!q"; actions = ["quit"]; deferred = true;}
-	];
+          {
+            binding = "ctrl-q";
+            actions = ["stop" "quit"];
+          }
+          {
+            binding = "q";
+            actions = ["quit"];
+            deferred = true;
+          }
+        ];
+        commands = [
+          {
+            binding = "!sq";
+            actions = ["stop" "quit"];
+          }
+          {
+            binding = "!q";
+            actions = ["quit"];
+            deferred = true;
+          }
+        ];
       };
     };
   };

--- a/modules/lib/generators/ncmpcpp.nix
+++ b/modules/lib/generators/ncmpcpp.nix
@@ -11,7 +11,7 @@ in {
               then "deferred"
               else "immediate"
             }]
-              ${concatStringsSep "\n" attrset.actions}
+              ${concatStringsSep "\n  " attrset.actions}
           ''
         )
         submodule);

--- a/modules/lib/types/ncmpcppBindingType.nix
+++ b/modules/lib/types/ncmpcppBindingType.nix
@@ -1,7 +1,7 @@
 {lib}: let
   inherit (lib.types) nullOr listOf bool str submodule;
   inherit (lib.options) mkOption;
-in ( 
+in (
   submodule {
     options = {
       binding = mkOption {

--- a/modules/tests/default.nix
+++ b/modules/tests/default.nix
@@ -1,0 +1,47 @@
+# Helper function to import the testing framework with special args.
+#
+# This function imports runTest from nixpkgs:/nixos/lib/testing-lib/runTest
+# to run our test derivation (the argument of this function),
+# passing some args in the process, notably self, allowing us to
+# use inputs and outputs from our flake.
+#
+# Usage: (import ./location-of-lib.nix) {test-script-here}
+{
+  pkgs,
+  self,
+  lib,
+  testDirectory,
+}: let
+  inherit (builtins) filter;
+  inherit (lib.trivial) pipe;
+  inherit (lib.strings) hasSuffix;
+  inherit (lib.filesystem) listFilesRecursive;
+  nixos-lib = import (pkgs.path + "/nixos/lib") {};
+  tests = pipe testDirectory [
+    listFilesRecursive
+    (filter (hasSuffix ".nix"))
+    (filter (x: !hasSuffix "lib.nix" x))
+  ];
+in
+  (nixos-lib.runTest {
+    hostPkgs = pkgs;
+    defaults = {
+      documentation.enable = lib.mkDefault false;
+      imports = [
+        self.inputs.hjem.nixosModules.default
+        self.nixosModules.default
+      ];
+      users.groups.bob = {};
+      users.users.bob = {
+        isNormalUser = true;
+        password = "";
+      };
+    };
+    node.specialArgs = {
+      inherit self;
+      inherit lib;
+    };
+    imports = tests;
+  })
+  .config
+  .result

--- a/modules/tests/programs/ncmpcpp/expected_bindings
+++ b/modules/tests/programs/ncmpcpp/expected_bindings
@@ -1,0 +1,13 @@
+def_key "ctrl-q" [immediate]
+  stop
+  quit
+
+def_key "q" [deferred]
+  quit
+
+def_command "!sq" [immediate]
+  stop
+  quit
+
+def_command "!q" [deferred]
+  quit

--- a/modules/tests/programs/ncmpcpp/expected_config
+++ b/modules/tests/programs/ncmpcpp/expected_config
@@ -1,0 +1,4 @@
+incremental_seeking = yes
+mpd_crossfade_time = 32
+mpd_host = localhost
+mpd_port = 6600

--- a/modules/tests/programs/ncmpcpp/ncmpcpp.nix
+++ b/modules/tests/programs/ncmpcpp/ncmpcpp.nix
@@ -1,0 +1,67 @@
+{...}: {
+  name = "ncmpcpp-test";
+  nodes = {
+    machine = {
+      hjem.users.bob.rum = {
+        programs.ncmpcpp = {
+          enable = true;
+
+          # This aims to test the ncmpcpp generator type conversion
+          # Options were chose at random
+          settings = {
+            mpd_host = "localhost";
+            mpd_port = 6600;
+            mpd_crossfade_time = 32;
+            incremental_seeking = true;
+          };
+
+          bindings = {
+            keys = [
+              {
+                binding = "ctrl-q";
+                actions = ["stop" "quit"];
+              }
+              {
+                binding = "q";
+                actions = ["quit"];
+                deferred = true;
+              }
+            ];
+            commands = [
+              {
+                binding = "!sq";
+                actions = ["stop" "quit"];
+              }
+              {
+                binding = "!q";
+                actions = ["quit"];
+                deferred = true;
+              }
+            ];
+          };
+        };
+      };
+    };
+  };
+  testScript = ''
+    # Waiting for our user to load.
+    machine.succeed("loginctl enable-linger bob")
+    machine.wait_for_unit("default.target")
+
+    # Checks if ncmpcpp config file exists in the expected place.
+    machine.succeed("[ -r ~bob/.config/ncmpcpp/config ]")
+
+    # Checks if ncmpcpp bindings file exists in the expected place.
+    machine.succeed("[ -r ~bob/.config/ncmpcpp/bindings ]")
+
+    # These statements copy the specified files from the nix sandbox (left argument)
+    # and write them to a specified location in the host vm (right argument).
+    # By doing this, we can access these files from our vm shell!
+    machine.copy_from_host("${./expected_config}", "/home/bob/expected_config")
+    machine.copy_from_host("${./expected_bindings}", "/home/bob/expected_bindings")
+
+    # Assert that both files have the expected content.
+    machine.succeed("diff -u -Z -b -B /home/bob/.config/ncmpcpp/config /home/bob/expected_config")
+    machine.succeed("diff -u -Z -b -B /home/bob/.config/ncmpcpp/bindings /home/bob/expected_bindings")
+  '';
+}


### PR DESCRIPTION
This PR adds support for tests using the internal ``runTest`` function (which ``lib.tests.runNixOSTest`` wraps). It also includes an example test module and a md file detailing how the system works.

The only thing i couldn't get working at the time of writing is passing our extended lib to the modules called by runTest, but the normal lib works just fine.

@Lunarnovaa @nezia1 