### PR TITLE
Add documentation

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,54 @@
+name: "Build and deploy documentation"
+
+on:
+  pull_request: # testing workflow
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      # build the manuals only when docs directory is updated
+      - docs/**
+      - modules/**
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  check_date:
+    runs-on: ubuntu-latest
+    name: Check latest commit
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: print latest_commit
+        run: echo ${{ github.sha }}
+
+      - id: should_run
+        continue-on-error: true
+        name: check latest commit is less than a day
+        if: ${{ github.event_name == 'schedule' }}
+        run: test -z $(git rev-list --after="24 hours" ${{ github.sha }}) && echo "::set-output name=should_run::false"
+
+  publish:
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: DeterminateSystems/nix-installer-action@main
+      - run: |
+          nix build .#docs -Lv
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./result

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -216,7 +216,7 @@ list of actions that get propagated accordingly:
     };
     description = ''
       Sets of keymaps and actions converted into TOML and written to
-      `${config.directory}/.config/spotify-player/keymap.toml`.
+      {file}`$HOME/.config/spotify-player/keymap.toml`.
       See example for how to format declarations.
 
       Please reference https://github.com/aome510/spotify-player/blob/master/docs/config.md#keymaps

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -134,6 +134,11 @@ configured by the user.
 
 ### Writing Options
 
+> [!IMPORTANT]
+> When writing options for any Nix module, do NOT make any option depend on a
+> value from `config`. Options should be pure, or it will interfere with modules
+> evaluation.
+
 Writing new options is the core of any new module. It is also the easiest place
 to blunder. As stated above, a core principle of HJR is to minimize the number
 of options as much as possible. As such, we have created a general template that

--- a/docs/manpage-urls.json
+++ b/docs/manpage-urls.json
@@ -1,0 +1,6 @@
+{
+  "fuzzel.ini(5)": "https://man.archlinux.org/man/fuzzel.ini.5",
+  "tofi(5)": "https://github.com/philj56/tofi/blob/master/doc/tofi.5.md",
+  "ncmpcpp(1)": "https://man.archlinux.org/man/ncmpcpp.1",
+  "foot.ini(5)": "https://man.archlinux.org/man/foot.ini.5.en"
+}

--- a/docs/package.nix
+++ b/docs/package.nix
@@ -1,0 +1,121 @@
+{
+  ndg,
+  pkgs,
+  lib,
+  rumLib,
+}: let
+  inherit (builtins) isAttrs toString;
+  inherit (lib.attrsets) isDerivation mapAttrs optionalAttrs;
+  inherit (lib.filesystem) listFilesRecursive;
+  inherit (lib.modules) mkForce evalModules;
+  inherit (lib.options) mkOption;
+  inherit (lib.strings) hasPrefix removePrefix;
+  inherit (lib.trivial) pipe;
+
+  configJSON =
+    (pkgs.nixosOptionsDoc {
+      variablelistId = "hjr-options";
+      warningsAreErrors = true;
+
+      inherit
+        (
+          (evalModules {
+            specialArgs = {inherit rumLib;};
+            modules =
+              (listFilesRecursive ../modules/collection)
+              ++ [
+                (
+                  let
+                    # From nixpkgs:
+                    #
+                    # Recursively replace each derivation in the given attribute set
+                    # with the same derivation but with the `outPath` attribute set to
+                    # the string `"\${pkgs.attribute.path}"`. This allows the
+                    # documentation to refer to derivations through their values without
+                    # establishing an actual dependency on the derivation output.
+                    #
+                    # This is not perfect, but it seems to cover a vast majority of use cases.
+                    #
+                    # Caveat: even if the package is reached by a different means, the
+                    # path above will be shown and not e.g.
+                    # `${config.services.foo.package}`.
+                    scrubDerivations = namePrefix: pkgSet:
+                      mapAttrs (
+                        name: value: let
+                          wholeName = "${namePrefix}.${name}";
+                        in
+                          if isAttrs value
+                          then
+                            scrubDerivations wholeName value
+                            // optionalAttrs (isDerivation value) {
+                              inherit (value) drvPath;
+                              outPath = "\${${wholeName}}";
+                            }
+                          else value
+                      )
+                      pkgSet;
+                  in {
+                    _module = {
+                      check = false;
+                      args.pkgs = mkForce (scrubDerivations "pkgs" pkgs);
+                    };
+                  }
+                )
+                # avoid having `_module.args` in the documentation
+                {
+                  options = {
+                    _module.args = mkOption {
+                      internal = true;
+                    };
+                  };
+                }
+              ];
+          })
+        )
+        options
+        ;
+
+      transformOptions = opt:
+        opt
+        // {
+          declarations =
+            map (
+              decl:
+                if hasPrefix (toString ../.) (toString decl)
+                then
+                  pipe decl [
+                    toString
+                    (removePrefix (toString ../.))
+                    (removePrefix "/")
+                    (x: {
+                      url = "https://github.com/snugnug/hjem-rum/blob/main/${x}";
+                      name = "<hjem-rum/${x}>";
+                    })
+                  ]
+                else if decl == "lib/modules.nix"
+                then {
+                  url = "https://github.com/NixOS/nixpkgs/blob/master/${decl}";
+                  name = "<nixpkgs/lib/modules.nix>";
+                }
+                else decl
+            )
+            opt.declarations;
+        };
+    })
+    .optionsJSON;
+
+  hjemRumDocs =
+    pkgs.runCommandLocal "hjr-docs" {nativeBuildInputs = [ndg];}
+    ''
+      mkdir -p $out
+
+      ndg --verbose html \
+        --jobs $NIX_BUILD_CORES --title "Hjem Rum" \
+        --module-options ${configJSON}/share/doc/nixos/options.json \
+        --manpage-urls ${./manpage-urls.json} \
+        --options-depth 2 \
+        --generate-search true \
+        --output-dir "$out"
+    '';
+in
+  hjemRumDocs

--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,62 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "ndg": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746459301,
+        "narHash": "sha256-QcAaxXdcPMqY5IppLa9fHCq3Rzq597DQqq8s2fKuE0k=",
+        "owner": "feel-co",
+        "repo": "ndg",
+        "rev": "2864a9901102a86db82157f72998809c570c36bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "feel-co",
+        "ref": "v2",
+        "repo": "ndg",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1737062831,
@@ -52,9 +108,25 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "hjem": "hjem",
+        "ndg": "ndg",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -78,27 +78,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737062831,
-        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "lastModified": 1746328495,
+        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1735471104,
-        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,12 +11,17 @@
       url = "github:feel-co/hjem";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    ndg = {
+      url = "github:feel-co/ndg/v2";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
     treefmt-nix,
+    ndg,
     ...
   }: let
     supportedSystems = ["x86_64-linux" "aarch64-linux"];
@@ -54,7 +59,12 @@
       };
       default = self.nixosModules.hjem-rum;
     };
-
+    packages = forAllSystems (pkgs: {
+      docs = pkgs.callPackage ./docs/package.nix {
+        inherit (ndg.packages.${pkgs.system}) ndg;
+        inherit rumLib;
+      };
+    });
     lib = rumLib;
 
     devShells = forAllSystems (

--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -46,8 +46,8 @@ in {
       description = ''
         The settings that will be written to the various gtk files
         to configure the GTK theme. GTK documentation is perhaps
-        nebulous, but the Arch Wiki entry and the official GTK
-        documentation (https://docs.gtk.org/gtk3/class.Settings.html)
+        nebulous, but the Arch Wiki entry and the [official GTK
+        documentation](https://docs.gtk.org/gtk3/class.Settings.html)
         are decent places to start.
 
         Please note that each option name will have "gtk-" prepended

--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -59,7 +59,7 @@ in {
         type = lines;
         default = "";
         description = ''
-          CSS to be written to '${config.directory}/.config/gtk-3.0/gtk.css'.
+          CSS to be written to '''''${config.directory}/.config/gtk-3.0/gtk.css'.
           You can either use this as lines or you can reference
           a CSS file from your theme's package (or both).
         '';
@@ -68,7 +68,7 @@ in {
         type = lines;
         default = "";
         description = ''
-          CSS to be written to '${config.directory}/.config/gtk-4.0/gtk.css'.
+          CSS to be written to '''''${config.directory}/.config/gtk-4.0/gtk.css'.
           You can either use this as lines or you can reference
           a CSS file from your theme's package (or both).
         '';

--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -48,12 +48,14 @@ in {
       description = ''
         The settings that will be written to the various gtk files
         to configure the GTK theme. GTK documentation is perhaps
-        nebulous, but the [Arch Wiki entry](https://wiki.archlinux.org/title/GTK)
-        and the [official GTK documentation](https://docs.gtk.org/gtk3/class.Settings.html)
-        are decent places to start.
+        nebulous, but the [Arch Wiki entry] and the [official GTK
+        documentation] are decent places to start.
 
         Please note that each option name will have "gtk-" prepended
         to it, so there is no need to include that on every single option.
+
+        [Arch Wiki entry]: https://wiki.archlinux.org/title/GTK
+        [official GTK documentation]: https://docs.gtk.org/gtk3/class.Settings.html
       '';
     };
     css = {

--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -7,7 +7,7 @@
 }: let
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.types) listOf package lines str;
-  inherit (lib.modules) mkIf;
+  inherit (lib.modules) mkIf mkRenamedOptionModule;
   inherit (lib.lists) optionals;
   inherit (lib.attrsets) optionalAttrs;
   inherit (rumLib.generators.gtk) toGtk2Text toGtkINI;
@@ -17,7 +17,8 @@
 
   cfg = config.rum.gtk;
 in {
-  options.rum.gtk = {
+  imports = [(mkRenamedOptionModule ["rum" "gtk"] ["rum" "misc" "gtk"])];
+  options.rum.misc.gtk = {
     enable = mkEnableOption "GTK configuration";
     packages = mkOption {
       type = listOf package;

--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -1,11 +1,10 @@
 {
-  pkgs,
   lib,
   config,
   rumLib,
   ...
 }: let
-  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.options) literalExpression mkOption mkEnableOption;
   inherit (lib.types) listOf package lines str;
   inherit (lib.modules) mkIf mkRenamedOptionModule;
   inherit (lib.lists) optionals;
@@ -23,13 +22,15 @@ in {
     packages = mkOption {
       type = listOf package;
       default = [];
-      example = [
-        (pkgs.catppuccin-papirus-folders.override {
-          accent = "rosewater";
-          flavor = "mocha";
-        })
-        pkgs.bibata-cursors
-      ];
+      example = literalExpression ''
+        [
+          (pkgs.catppuccin-papirus-folders.override {
+            accent = "rosewater";
+            flavor = "mocha";
+          })
+          pkgs.bibata-cursors
+        ];
+      '';
       description = ''
         The list of packages to be installed for gtk themes.
         This list should consist of any packages that will be used

--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -59,7 +59,7 @@ in {
         type = lines;
         default = "";
         description = ''
-          CSS to be written to '''''${config.directory}/.config/gtk-3.0/gtk.css'.
+          CSS to be written to {file}`$HOME/.config/gtk-3.0/gtk.css`.
           You can either use this as lines or you can reference
           a CSS file from your theme's package (or both).
         '';
@@ -68,7 +68,7 @@ in {
         type = lines;
         default = "";
         description = ''
-          CSS to be written to '''''${config.directory}/.config/gtk-4.0/gtk.css'.
+          CSS to be written to {file}`$HOME/.config/gtk-4.0/gtk.css`.
           You can either use this as lines or you can reference
           a CSS file from your theme's package (or both).
         '';

--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -48,8 +48,8 @@ in {
       description = ''
         The settings that will be written to the various gtk files
         to configure the GTK theme. GTK documentation is perhaps
-        nebulous, but the Arch Wiki entry and the [official GTK
-        documentation](https://docs.gtk.org/gtk3/class.Settings.html)
+        nebulous, but the [Arch Wiki entry](https://wiki.archlinux.org/title/GTK)
+        and the [official GTK documentation](https://docs.gtk.org/gtk3/class.Settings.html)
         are decent places to start.
 
         Please note that each option name will have "gtk-" prepended

--- a/modules/collection/programs/alacritty.nix
+++ b/modules/collection/programs/alacritty.nix
@@ -35,7 +35,7 @@ in {
       description = ''
         The configuration converted into TOML and written to
         {file}`$HOME/.config/alacritty/alacritty.toml`.
-        Please reference [https://alacritty.org/config-alacritty.html](https://alacritty.org/config-alacritty.html)
+        Please reference [Alacritty's documentation](https://alacritty.org/config-alacritty.html)
         for config options.
       '';
     };

--- a/modules/collection/programs/alacritty.nix
+++ b/modules/collection/programs/alacritty.nix
@@ -34,7 +34,7 @@ in {
       };
       description = ''
         The configuration converted into TOML and written to
-        `${config.directory}/.config/alacritty/alacritty.toml`.
+        `''${config.directory}/.config/alacritty/alacritty.toml`.
         Please reference https://alacritty.org/config-alacritty.html
         for config options.
       '';

--- a/modules/collection/programs/alacritty.nix
+++ b/modules/collection/programs/alacritty.nix
@@ -34,8 +34,8 @@ in {
       };
       description = ''
         The configuration converted into TOML and written to
-        `''${config.directory}/.config/alacritty/alacritty.toml`.
-        Please reference https://alacritty.org/config-alacritty.html
+        {file}`$HOME/.config/alacritty/alacritty.toml`.
+        Please reference [https://alacritty.org/config-alacritty.html](https://alacritty.org/config-alacritty.html)
         for config options.
       '';
     };

--- a/modules/collection/programs/alacritty.nix
+++ b/modules/collection/programs/alacritty.nix
@@ -35,8 +35,10 @@ in {
       description = ''
         The configuration converted into TOML and written to
         {file}`$HOME/.config/alacritty/alacritty.toml`.
-        Please reference [Alacritty's documentation](https://alacritty.org/config-alacritty.html)
+        Please reference [Alacritty's documentation]
         for config options.
+
+        [Alacritty's documentation]: https://alacritty.org/config-alacritty.html
       '';
     };
   };

--- a/modules/collection/programs/bottom.nix
+++ b/modules/collection/programs/bottom.nix
@@ -30,8 +30,10 @@ in {
         The configuration converted into TOML and written to
         {file}`$HOME/.config/bottom/bottom.toml`.
 
-        Please reference [bottom's config file documentation](https://bottom.pages.dev/stable/configuration/config-file/)
+        Please reference [bottom's config file documentation]
         for config options.
+
+        [bottom's config file documentation]: https://bottom.pages.dev/stable/configuration/config-file
       '';
     };
   };

--- a/modules/collection/programs/bottom.nix
+++ b/modules/collection/programs/bottom.nix
@@ -30,7 +30,7 @@ in {
         The configuration converted into TOML and written to
         {file}`$HOME/.config/bottom/bottom.toml`.
 
-        Please reference https://bottom.pages.dev/stable/configuration/config-file/
+        Please reference [bottom's config file documentation](https://bottom.pages.dev/stable/configuration/config-file/)
         for config options.
       '';
     };

--- a/modules/collection/programs/fish.nix
+++ b/modules/collection/programs/fish.nix
@@ -4,7 +4,7 @@
   config,
   ...
 }: let
-  inherit (lib.options) mkOption mkEnableOption mkPackageOption literalExample;
+  inherit (lib.options) literalExpression mkOption mkEnableOption mkPackageOption;
   inherit (lib.strings) typeOf concatMapAttrsStringSep concatMapStringsSep splitString escapeShellArg;
   inherit (lib.modules) mkIf;
   inherit (lib.types) either str path oneOf attrsOf nullOr;
@@ -78,7 +78,7 @@ in {
 
         Otherwise you are expected to handle that yourself.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           fish_prompt = pkgs.writers.writeFish "fish_prompt.fish" '\'
               function fish_prompt -d "Write out the prompt"
@@ -146,7 +146,7 @@ in {
 
         If a plugin seems to not work, verify that it contains one of the aformentioned files.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           inherit (pkgs.fishPlugins) z;
           pisces = pkgs.fetchFromGitHub {

--- a/modules/collection/programs/fish.nix
+++ b/modules/collection/programs/fish.nix
@@ -71,11 +71,10 @@ in {
         If the input value is a string, its contents will be wrapped
         inside of a function declaration, like so:
         ```fish
-            function <name>;
-                <function body>
-            end
+        function <name>;
+            <function body>
+        end
         ```
-
         Otherwise you are expected to handle that yourself.
       '';
       example = literalExpression ''

--- a/modules/collection/programs/fish.nix
+++ b/modules/collection/programs/fish.nix
@@ -101,8 +101,9 @@ in {
         Extra configuration files, they will all be written verbatim
         to `.config/fish/conf.d/<name>.fish`.
 
-        Those files are run before `.config/fish/config.fish` as per the fish
-        [documentation](https://fishshell.com/docs/current/language.html#configuration-files).
+        Those files are run before `.config/fish/config.fish` as per the [fish documentation].
+
+        [fish documentation]: https://fishshell.com/docs/current/language.html#configuration-files
       '';
       example = {
         my-aliases = ''

--- a/modules/collection/programs/foot.nix
+++ b/modules/collection/programs/foot.nix
@@ -40,7 +40,7 @@ in {
         };
       };
       description = ''
-        Settings are written as an INI file to ''${config.directory}/.config/foot/foot.ini.
+        Settings are written as an INI file to {file}`$HOME/.config/foot/foot.ini`.
 
         Refer to https://codeberg.org/dnkl/foot/src/branch/master/foot.ini for
         all available options.

--- a/modules/collection/programs/foot.nix
+++ b/modules/collection/programs/foot.nix
@@ -40,7 +40,7 @@ in {
         };
       };
       description = ''
-        Settings are written as an INI file to ${config.directory}/.config/foot/foot.ini.
+        Settings are written as an INI file to ''${config.directory}/.config/foot/foot.ini.
 
         Refer to https://codeberg.org/dnkl/foot/src/branch/master/foot.ini for
         all available options.

--- a/modules/collection/programs/foot.nix
+++ b/modules/collection/programs/foot.nix
@@ -42,8 +42,10 @@ in {
       description = ''
         Settings are written as an INI file to {file}`$HOME/.config/foot/foot.ini`.
 
-        Refer to {manpage}`foot.ini(5)` or the [upstream template](https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes)
+        Refer to {manpage}`foot.ini(5)` or the [upstream template]
         for all available options.
+
+        [upstream template]: https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes
       '';
     };
   };

--- a/modules/collection/programs/foot.nix
+++ b/modules/collection/programs/foot.nix
@@ -42,8 +42,8 @@ in {
       description = ''
         Settings are written as an INI file to {file}`$HOME/.config/foot/foot.ini`.
 
-        Refer to https://codeberg.org/dnkl/foot/src/branch/master/foot.ini for
-        all available options.
+        Refer to {manpage}`foot.ini(5)` or the [upstream template](https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes)
+        for all available options.
       '';
     };
   };

--- a/modules/collection/programs/fuzzel.nix
+++ b/modules/collection/programs/fuzzel.nix
@@ -27,7 +27,7 @@ in {
         colors.background = "ffffffff";
       };
       description = ''
-        Is written to `${config.directory}/fuzzel/fuzzel.ini`.
+        Is written to `''${config.directory}/fuzzel/fuzzel.ini`.
 
         Consult [man 5 fuzzel.ini](https://www.mankier.com/5/fuzzel.ini).
       '';

--- a/modules/collection/programs/fuzzel.nix
+++ b/modules/collection/programs/fuzzel.nix
@@ -29,7 +29,7 @@ in {
       description = ''
         Is written to {file}`$HOME/fuzzel/fuzzel.ini`.
 
-        Consult [man 5 fuzzel.ini](https://www.mankier.com/5/fuzzel.ini).
+        Please reference {manpage}`fuzzel.ini(5)` for configuration options.
       '';
     };
   };

--- a/modules/collection/programs/fuzzel.nix
+++ b/modules/collection/programs/fuzzel.nix
@@ -27,7 +27,7 @@ in {
         colors.background = "ffffffff";
       };
       description = ''
-        Is written to `''${config.directory}/fuzzel/fuzzel.ini`.
+        Is written to {file}`$HOME/fuzzel/fuzzel.ini`.
 
         Consult [man 5 fuzzel.ini](https://www.mankier.com/5/fuzzel.ini).
       '';

--- a/modules/collection/programs/gammastep.nix
+++ b/modules/collection/programs/gammastep.nix
@@ -32,9 +32,9 @@ in {
       };
       description = ''
         Settings are written as an INI file to {file}`$HOME/.config/gammastep/config.ini`.
+        Refer to [gammastep's example configuration] all available options.
 
-        Refer to https://gitlab.com/chinstrap/gammastep/-/blob/master/gammastep.conf.sample for
-        all available options.
+        [gammastep's example configuration]: https://gitlab.com/chinstrap/gammastep/-/blob/master/gammastep.conf.sample
       '';
     };
   };

--- a/modules/collection/programs/ghostty.nix
+++ b/modules/collection/programs/ghostty.nix
@@ -56,8 +56,10 @@ in {
       };
       description = ''
         The configuration converted to INI and written to {file}`$HOME/.config/ghostty/config`.
-        Please consult [Ghostty's option reference](https://ghostty.org/docs/config/reference)
+        Please consult [Ghostty's option reference]
         for configuration options.
+
+        [Ghostty's option reference]: https://ghostty.org/docs/config/reference
       '';
     };
     themes = mkOption {
@@ -93,8 +95,10 @@ in {
       };
       description = ''
         An attribute set of themes, with the key as the theme name.
-        Please reference [Ghostty's color theme documentation](https://ghostty.org/docs/features/theme)
+        Please reference [Ghostty's color theme documentation]
         for configuration options.
+
+        [Ghostty's color theme documentation]: https://ghostty.org/docs/features/theme
       '';
     };
   };

--- a/modules/collection/programs/ghostty.nix
+++ b/modules/collection/programs/ghostty.nix
@@ -56,7 +56,7 @@ in {
         ];
       };
       description = ''
-        The configuration converted to INI and written to `${config.directory}/.config/ghostty/config`.
+        The configuration converted to INI and written to `''${config.directory}/.config/ghostty/config`.
         Please reference https://ghostty.org/docs/config/reference for config options.
       '';
     };

--- a/modules/collection/programs/ghostty.nix
+++ b/modules/collection/programs/ghostty.nix
@@ -35,12 +35,11 @@ in {
     package = mkPackageOption pkgs "ghostty" {
       extraDescription = ''
         You can use an override to configure some settings baked into the package.
-
-        ```nix
-        package = pkgs.ghostty.override {
+      '';
+      example = ''
+        pkgs.ghostty.override {
           withAdwaita = true;
         };
-        ```
       '';
     };
 

--- a/modules/collection/programs/ghostty.nix
+++ b/modules/collection/programs/ghostty.nix
@@ -57,8 +57,8 @@ in {
       };
       description = ''
         The configuration converted to INI and written to {file}`$HOME/.config/ghostty/config`.
-        Please reference [https://ghostty.org/docs/config/reference](https://ghostty.org/docs/config/reference)
-        for config options.
+        Please consult [Ghostty's option reference](https://ghostty.org/docs/config/reference)
+        for configuration options.
       '';
     };
     themes = mkOption {
@@ -94,7 +94,8 @@ in {
       };
       description = ''
         An attribute set of themes, with the key as the theme name.
-        Please reference https://ghostty.org/docs/features/theme for config options.
+        Please reference [Ghostty's color theme documentation](https://ghostty.org/docs/features/theme)
+        for configuration options.
       '';
     };
   };

--- a/modules/collection/programs/ghostty.nix
+++ b/modules/collection/programs/ghostty.nix
@@ -56,8 +56,9 @@ in {
         ];
       };
       description = ''
-        The configuration converted to INI and written to `''${config.directory}/.config/ghostty/config`.
-        Please reference https://ghostty.org/docs/config/reference for config options.
+        The configuration converted to INI and written to {file}`$HOME/.config/ghostty/config`.
+        Please reference [https://ghostty.org/docs/config/reference](https://ghostty.org/docs/config/reference)
+        for config options.
       '';
     };
     themes = mkOption {

--- a/modules/collection/programs/git.nix
+++ b/modules/collection/programs/git.nix
@@ -47,7 +47,7 @@ in {
       default = ".gitconfig";
       description = ''
         Select your preferred git config location. Do note that options set in
-        `~/.gitconfig` will shadow anything set in `.config/git/config`.
+        {file}`$HOME/.gitconfig` will shadow anything set in `.config/git/config`.
       '';
     };
   };

--- a/modules/collection/programs/helix.nix
+++ b/modules/collection/programs/helix.nix
@@ -41,10 +41,10 @@ in {
       };
       description = ''
         The editor configuration converted into TOML and written to
-        `''${config.directory}/.config/helix/config.toml`.
-        Please reference https://docs.helix-editor.com/editor.html
-        and https://docs.helix-editor.com/remapping.html for config
-        options.
+        {file}`$HOME/.config/helix/config.toml`.
+        Please reference [https://docs.helix-editor.com/editor.html](https://docs.helix-editor.com/editor.html)
+        and [https://docs.helix-editor.com/remapping.html](https://docs.helix-editor.com/remapping.html) for
+        config options.
       '';
     };
 
@@ -56,8 +56,8 @@ in {
       };
       description = ''
         The languages configurations converted into TOML and written to
-        `''${config.directory}/.config/helix/languages.toml`.
-        Please reference https://docs.helix-editor.com/languages.html
+        {file}`$HOME/.config/helix/languages.toml`.
+        Please reference [https://docs.helix-editor.com/languages.html](https://docs.helix-editor.com/languages.html)
         for config options.
       '';
     };
@@ -77,8 +77,8 @@ in {
       };
       description = ''
         The custom themes converted into TOML and written to
-        `''${config.directory}/.config/helix/themes/`.
-        Please reference https://docs.helix-editor.com/themes.html
+        {file}`$HOME/.config/helix/themes/`.
+        Please reference [https://docs.helix-editor.com/themes.html](https://docs.helix-editor.com/themes.html)
         for config options.
       '';
     };

--- a/modules/collection/programs/helix.nix
+++ b/modules/collection/programs/helix.nix
@@ -41,7 +41,7 @@ in {
       };
       description = ''
         The editor configuration converted into TOML and written to
-        `${config.directory}/.config/helix/config.toml`.
+        `''${config.directory}/.config/helix/config.toml`.
         Please reference https://docs.helix-editor.com/editor.html
         and https://docs.helix-editor.com/remapping.html for config
         options.
@@ -56,7 +56,7 @@ in {
       };
       description = ''
         The languages configurations converted into TOML and written to
-        `${config.directory}/.config/helix/languages.toml`.
+        `''${config.directory}/.config/helix/languages.toml`.
         Please reference https://docs.helix-editor.com/languages.html
         for config options.
       '';
@@ -77,7 +77,7 @@ in {
       };
       description = ''
         The custom themes converted into TOML and written to
-        `${config.directory}/.config/helix/themes/`.
+        `''${config.directory}/.config/helix/themes/`.
         Please reference https://docs.helix-editor.com/themes.html
         for config options.
       '';

--- a/modules/collection/programs/helix.nix
+++ b/modules/collection/programs/helix.nix
@@ -41,9 +41,10 @@ in {
       };
       description = ''
         The editor configuration converted into TOML and written to
-        {file}`$HOME/.config/helix/config.toml`.
-        Please reference [Helix's documentation](https://docs.helix-editor.com/editor.html)
-        for config options.
+        {file}`$HOME/.config/helix/config.toml`. Please reference
+        [Helix's documentation] for config options.
+
+        [Helix's documentation]: https://docs.helix-editor.com/editor.html
       '';
     };
 
@@ -55,9 +56,10 @@ in {
       };
       description = ''
         The languages configurations converted into TOML and written to
-        {file}`$HOME/.config/helix/languages.toml`.
-        Please reference [Helix's language documentation](https://docs.helix-editor.com/languages.html)
-        for config options.
+        {file}`$HOME/.config/helix/languages.toml`. Please reference
+        [Helix's language documentation] for config options.
+
+        [Helix's language documentation]: https://docs.helix-editor.com/languages.html
       '';
     };
 
@@ -76,9 +78,10 @@ in {
       };
       description = ''
         The custom themes converted into TOML and written to
-        {file}`$HOME/.config/helix/themes/`.
-        Please reference [Helix's theming documentation](https://docs.helix-editor.com/themes.html)
-        for config options.
+        {file}`$HOME/.config/helix/themes/`. Please reference
+        [Helix's theming documentation] for config options.
+
+        [Helix's theming documentation]: https://docs.helix-editor.com/themes.html
       '';
     };
   };

--- a/modules/collection/programs/helix.nix
+++ b/modules/collection/programs/helix.nix
@@ -42,9 +42,8 @@ in {
       description = ''
         The editor configuration converted into TOML and written to
         {file}`$HOME/.config/helix/config.toml`.
-        Please reference [https://docs.helix-editor.com/editor.html](https://docs.helix-editor.com/editor.html)
-        and [https://docs.helix-editor.com/remapping.html](https://docs.helix-editor.com/remapping.html) for
-        config options.
+        Please reference [Helix's documentation](https://docs.helix-editor.com/editor.html)
+        for config options.
       '';
     };
 
@@ -57,7 +56,7 @@ in {
       description = ''
         The languages configurations converted into TOML and written to
         {file}`$HOME/.config/helix/languages.toml`.
-        Please reference [https://docs.helix-editor.com/languages.html](https://docs.helix-editor.com/languages.html)
+        Please reference [Helix's language documentation](https://docs.helix-editor.com/languages.html)
         for config options.
       '';
     };
@@ -78,7 +77,7 @@ in {
       description = ''
         The custom themes converted into TOML and written to
         {file}`$HOME/.config/helix/themes/`.
-        Please reference [https://docs.helix-editor.com/themes.html](https://docs.helix-editor.com/themes.html)
+        Please reference [Helix's theming documentation](https://docs.helix-editor.com/themes.html)
         for config options.
       '';
     };

--- a/modules/collection/programs/hypridle.nix
+++ b/modules/collection/programs/hypridle.nix
@@ -41,7 +41,9 @@ in {
       description = ''
         Is written to {file}`$HOME/hypr/hypridle.conf`.
 
-        Configuration options can be found on the [Hyprland Wiki](https://wiki.hyprland.org/Hypr-Ecosystem/hypridle).
+        Configuration options can be found on the [Hyprland Wiki].
+
+        [Hyprland Wiki]: https://wiki.hyprland.org/Hypr-Ecosystem/hypridle
       '';
     };
   };

--- a/modules/collection/programs/hyprland.nix
+++ b/modules/collection/programs/hyprland.nix
@@ -33,7 +33,8 @@ in {
       description = ''
         Hyprland configuration written in Nix. Entries with the same key
         should be written as lists. Variables' and colors' names should be
-        quoted. See <https://wiki.hyprland.org> for more examples.
+        quoted. See [Hyprland's documentation](https://wiki.hyprland.org)
+        for more examples.
       '';
     };
 

--- a/modules/collection/programs/hyprland.nix
+++ b/modules/collection/programs/hyprland.nix
@@ -33,8 +33,9 @@ in {
       description = ''
         Hyprland configuration written in Nix. Entries with the same key
         should be written as lists. Variables' and colors' names should be
-        quoted. See [Hyprland's documentation](https://wiki.hyprland.org)
-        for more examples.
+        quoted. See [Hyprland's documentation] for more examples.
+
+        [Hyprland's documentation]: https://wiki.hyprland.org
       '';
     };
 

--- a/modules/collection/programs/hyprlock.nix
+++ b/modules/collection/programs/hyprlock.nix
@@ -37,7 +37,9 @@ in {
       description = ''
         Is written to {file}`$HOME/hypr/hyprlock.conf`.
 
-        Configuration options can be found on the [Hyprland Wiki](https://wiki.hyprland.org/Hypr-Ecosystem/hyprlock).
+        Configuration options can be found on the [Hyprland Wiki].
+
+        [Hyprland Wiki]: https://wiki.hyprland.org/Hypr-Ecosystem/hyprlock
       '';
     };
   };

--- a/modules/collection/programs/hyprlock.nix
+++ b/modules/collection/programs/hyprlock.nix
@@ -35,7 +35,7 @@ in {
         ];
       };
       description = ''
-        Is written to `''${config.directory}/hypr/hyprlock.conf`.
+        Is written to {file}`$HOME/hypr/hyprlock.conf`.
 
         Configuration options can be found on the [Hyprland Wiki](https://wiki.hyprland.org/Hypr-Ecosystem/hyprlock).
       '';

--- a/modules/collection/programs/keepassxc.nix
+++ b/modules/collection/programs/keepassxc.nix
@@ -35,9 +35,11 @@ in {
       };
       description = ''
         Settings are written as an INI file to {file}`$HOME/.config/keepassxc/keepassxc.ini`. Please reference
-        [KeePassXC's User Guide](https://keepassxc.org/docs/KeePassXC_UserGuide).
+        [KeePassXC's User Guide].
 
         It also can be configured by toggling options through the GUI, but this does not seem documented.
+
+        [KeePassXC's User Guide]: https://keepassxc.org/docs/KeePassXC_UserGuide
       '';
     };
   };

--- a/modules/collection/programs/keepassxc.nix
+++ b/modules/collection/programs/keepassxc.nix
@@ -34,7 +34,7 @@ in {
         };
       };
       description = ''
-        Settings are written as an INI file to ${config.directory}/.config/keepassxc/keepassxc.ini.
+        Settings are written as an INI file to ''${config.directory}/.config/keepassxc/keepassxc.ini.
 
         Please consult https://keepassxc.org/docs/KeePassXC_UserGuide, but also
         a configuration you create by toggling options through the GUI, as it

--- a/modules/collection/programs/keepassxc.nix
+++ b/modules/collection/programs/keepassxc.nix
@@ -34,11 +34,10 @@ in {
         };
       };
       description = ''
-        Settings are written as an INI file to {file}`$HOME/.config/keepassxc/keepassxc.ini`.
+        Settings are written as an INI file to {file}`$HOME/.config/keepassxc/keepassxc.ini`. Please reference
+        [KeePassXC's User Guide](https://keepassxc.org/docs/KeePassXC_UserGuide).
 
-        Please consult https://keepassxc.org/docs/KeePassXC_UserGuide, but also
-        a configuration you create by toggling options through the GUI, as it
-        doesn't seem they are documented.
+        It also can be configured by toggling options through the GUI, but this does not seem documented.
       '';
     };
   };

--- a/modules/collection/programs/keepassxc.nix
+++ b/modules/collection/programs/keepassxc.nix
@@ -34,7 +34,7 @@ in {
         };
       };
       description = ''
-        Settings are written as an INI file to ''${config.directory}/.config/keepassxc/keepassxc.ini.
+        Settings are written as an INI file to {file}`$HOME/.config/keepassxc/keepassxc.ini`.
 
         Please consult https://keepassxc.org/docs/KeePassXC_UserGuide, but also
         a configuration you create by toggling options through the GUI, as it

--- a/modules/collection/programs/lsd.nix
+++ b/modules/collection/programs/lsd.nix
@@ -27,8 +27,9 @@ in {
       };
       description = ''
         Configuration written to {file}`$HOME/.config/lsd/config.yaml`, defining lsd settings.
-        Please reference  [lsd's example configuration](https://github.com/lsd-rs/lsd#config-file-content)
-        to configure it accordingly.
+        Please reference  [lsd's example configuration] to configure it accordingly.
+
+        [lsd's example configuration]: https://github.com/lsd-rs/lsd#config-file-content
       '';
     };
 
@@ -44,8 +45,9 @@ in {
       };
       description = ''
         Configuration written to {file}`$HOME/.config/lsd/icons.yaml`, defining the icons used by lsd.
-        Please reference [lsd's icon theme example](https://github.com/lsd-rs/lsd#icon-theme)
-        to configure it accordingly.
+        Please reference [lsd's icon theme example] to configure it accordingly.
+
+        [lsd's icon theme example]: https://github.com/lsd-rs/lsd#icon-theme
       '';
     };
 
@@ -62,8 +64,9 @@ in {
       };
       description = ''
         Configuration written to {file}`$HOME/.config/lsd/colors.yaml`, defining the colors used by lsd.
-        Please reference [lsd's color theme example](https://github.com/lsd-rs/lsd#color-theme-file-content)
-        to configure it accordingly.
+        Please reference [lsd's color theme example] to configure it accordingly.
+
+        [lsd's color theme example]: https://github.com/lsd-rs/lsd#color-theme-file-content
       '';
     };
   };

--- a/modules/collection/programs/lsd.nix
+++ b/modules/collection/programs/lsd.nix
@@ -26,7 +26,7 @@ in {
         };
       };
       description = ''
-        Configuration written to `${config.directory}/.config/lsd/config.yaml`, defining lsd settings.
+        Configuration written to `''${config.directory}/.config/lsd/config.yaml`, defining lsd settings.
         Please reference https://github.com/lsd-rs/lsd#config-file-content to configure it accordingly.
       '';
     };
@@ -42,7 +42,7 @@ in {
         };
       };
       description = ''
-        Configuration written to `${config.directory}/.config/lsd/icons.yaml`, defining the icons used by
+        Configuration written to `''${config.directory}/.config/lsd/icons.yaml`, defining the icons used by
         lsd.
         Please reference https://github.com/lsd-rs/lsd#icon-theme to configure it accordingly.
       '';
@@ -60,7 +60,7 @@ in {
         };
       };
       description = ''
-        Configuration written to `${config.directory}/.config/lsd/colors.yaml`, defining the colors used by
+        Configuration written to `''${config.directory}/.config/lsd/colors.yaml`, defining the colors used by
         lsd.
         Please reference https://github.com/lsd-rs/lsd#color-theme-file-content to configure it accordingly.
       '';

--- a/modules/collection/programs/lsd.nix
+++ b/modules/collection/programs/lsd.nix
@@ -27,7 +27,7 @@ in {
       };
       description = ''
         Configuration written to {file}`$HOME/.config/lsd/config.yaml`, defining lsd settings.
-        Please reference [https://github.com/lsd-rs/lsd#config-file-content](https://github.com/lsd-rs/lsd#config-file-content)
+        Please reference  [lsd's example configuration](https://github.com/lsd-rs/lsd#config-file-content)
         to configure it accordingly.
       '';
     };
@@ -44,7 +44,7 @@ in {
       };
       description = ''
         Configuration written to {file}`$HOME/.config/lsd/icons.yaml`, defining the icons used by lsd.
-        Please reference [https://github.com/lsd-rs/lsd#icon-theme](https://github.com/lsd-rs/lsd#icon-theme)
+        Please reference [lsd's icon theme example](https://github.com/lsd-rs/lsd#icon-theme)
         to configure it accordingly.
       '';
     };
@@ -62,7 +62,7 @@ in {
       };
       description = ''
         Configuration written to {file}`$HOME/.config/lsd/colors.yaml`, defining the colors used by lsd.
-        Please reference [https://github.com/lsd-rs/lsd#color-theme-file-content](https://github.com/lsd-rs/lsd#color-theme-file-content)
+        Please reference [lsd's color theme example](https://github.com/lsd-rs/lsd#color-theme-file-content)
         to configure it accordingly.
       '';
     };

--- a/modules/collection/programs/lsd.nix
+++ b/modules/collection/programs/lsd.nix
@@ -26,8 +26,9 @@ in {
         };
       };
       description = ''
-        Configuration written to `''${config.directory}/.config/lsd/config.yaml`, defining lsd settings.
-        Please reference https://github.com/lsd-rs/lsd#config-file-content to configure it accordingly.
+        Configuration written to {file}`$HOME/.config/lsd/config.yaml`, defining lsd settings.
+        Please reference [https://github.com/lsd-rs/lsd#config-file-content](https://github.com/lsd-rs/lsd#config-file-content)
+        to configure it accordingly.
       '';
     };
 
@@ -42,9 +43,9 @@ in {
         };
       };
       description = ''
-        Configuration written to `''${config.directory}/.config/lsd/icons.yaml`, defining the icons used by
-        lsd.
-        Please reference https://github.com/lsd-rs/lsd#icon-theme to configure it accordingly.
+        Configuration written to {file}`$HOME/.config/lsd/icons.yaml`, defining the icons used by lsd.
+        Please reference [https://github.com/lsd-rs/lsd#icon-theme](https://github.com/lsd-rs/lsd#icon-theme)
+        to configure it accordingly.
       '';
     };
 
@@ -60,9 +61,9 @@ in {
         };
       };
       description = ''
-        Configuration written to `''${config.directory}/.config/lsd/colors.yaml`, defining the colors used by
-        lsd.
-        Please reference https://github.com/lsd-rs/lsd#color-theme-file-content to configure it accordingly.
+        Configuration written to {file}`$HOME/.config/lsd/colors.yaml`, defining the colors used by lsd.
+        Please reference [https://github.com/lsd-rs/lsd#color-theme-file-content](https://github.com/lsd-rs/lsd#color-theme-file-content)
+        to configure it accordingly.
       '';
     };
   };

--- a/modules/collection/programs/ncmpcpp.nix
+++ b/modules/collection/programs/ncmpcpp.nix
@@ -42,7 +42,9 @@ in {
       };
       description = ''
         Configuration written to {file}`$HOME/.config/ncmpcpp/config`.
-        Please reference {manpage}`ncmpcpp(1)` to configure it accordingly, or consult [ncmpcpp's example configuration](https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/config).
+        Please reference {manpage}`ncmpcpp(1)` to configure it accordingly, or consult [ncmpcpp's example configuration].
+
+        [ncmpcpp's example configuration]: https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/config
       '';
     };
 
@@ -52,11 +54,12 @@ in {
       description = ''
         Custom bindings configuration written to {file}`$HOME/.config/ncmpcpp/bindings`.
         Please reference {manpage}`ncmpcpp(1)` to configure it accordingly, or consult
-        [ncmpcpp's example bindings file](https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/bindings).
-
+        [ncmpcpp's example bindings file].
 
         The lists are separated between keys, for actions ran on keypresses, and commands, for actions ran
         on commands. The option's example demonstrates this greatly.
+
+        [ncmpcpp's example bindings file]: https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/bindings
       '';
       example = {
         keys = [

--- a/modules/collection/programs/ncmpcpp.nix
+++ b/modules/collection/programs/ncmpcpp.nix
@@ -43,8 +43,7 @@ in {
       };
       description = ''
         Configuration written to {file}`$HOME/.config/ncmpcpp/config`.
-        Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access [https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/config](https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes)
-        for an example.
+        Please reference {manpage}`ncmpcpp(1)` to configure it accordingly, or consult [ncmpcpp's example configuration](https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/config).
       '';
     };
 
@@ -53,12 +52,12 @@ in {
       default = {};
       description = ''
         Custom bindings configuration written to {file}`$HOME/.config/ncmpcpp/bindings`.
-        Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access
-        [https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/bindings](https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes)
-        for an example.
+        Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or consult
+        [ncmpcpp's example bindings file](https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/bindings).
 
-        The lists are separated between keys, for actions ran on keypresses, and commands, for
-        actions ran on commands. The option's example demonstrates this greatly.
+
+        The lists are separated between keys, for actions ran on keypresses, and commands, for actions ran
+        on commands. The option's example demonstrates this greatly.
       '';
       example = {
         keys = [

--- a/modules/collection/programs/ncmpcpp.nix
+++ b/modules/collection/programs/ncmpcpp.nix
@@ -19,16 +19,15 @@ in {
     package = mkPackageOption pkgs "ncmpcpp" {
       extraDescription = ''
         You can override the package to customize certain settings that are baked into the package.
-
-        ```nix
-        package = pkgs.ncmpccpp.override {
+      '';
+      example = ''
+        pkgs.ncmpcpp.override {
           # useful overrides in the package
           outputsSupport = true; # outputs screen
           visualizerSupport = false; # visualizer screen
           clockSupport = true; # clock screen
           taglibSupport = true; # tag editor
         };
-        ```
       '';
     };
 

--- a/modules/collection/programs/ncmpcpp.nix
+++ b/modules/collection/programs/ncmpcpp.nix
@@ -42,7 +42,7 @@ in {
         statusbar_visibility = true;
       };
       description = ''
-        Configuration written to `${config.directory}/.config/ncmpcpp/config`.
+        Configuration written to `''${config.directory}/.config/ncmpcpp/config`.
         Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access
         https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/config for an example.
       '';
@@ -52,7 +52,7 @@ in {
       type = attrsOf (listOf ncmpcppBindingType);
       default = {};
       description = ''
-               Custom bindings configuration written to `${config.directory}/.config/ncmpcpp/bindings`.
+               Custom bindings configuration written to `''${config.directory}/.config/ncmpcpp/bindings`.
                Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access
                https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/bindings for an example.
 

--- a/modules/collection/programs/ncmpcpp.nix
+++ b/modules/collection/programs/ncmpcpp.nix
@@ -42,9 +42,9 @@ in {
         statusbar_visibility = true;
       };
       description = ''
-        Configuration written to `''${config.directory}/.config/ncmpcpp/config`.
-        Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access
-        https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/config for an example.
+        Configuration written to {file}`$HOME/.config/ncmpcpp/config`.
+        Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access [https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/config](https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes)
+        for an example.
       '';
     };
 
@@ -52,9 +52,10 @@ in {
       type = attrsOf (listOf ncmpcppBindingType);
       default = {};
       description = ''
-               Custom bindings configuration written to `''${config.directory}/.config/ncmpcpp/bindings`.
-               Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access
-               https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/bindings for an example.
+        Custom bindings configuration written to {file}`$HOME/.config/ncmpcpp/bindings`.
+        Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or access
+        [https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/bindings](https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes)
+        for an example.
 
         The lists are separated between keys, for actions ran on keypresses, and commands, for
         actions ran on commands. The option's example demonstrates this greatly.

--- a/modules/collection/programs/ncmpcpp.nix
+++ b/modules/collection/programs/ncmpcpp.nix
@@ -51,7 +51,7 @@ in {
       default = {};
       description = ''
         Custom bindings configuration written to {file}`$HOME/.config/ncmpcpp/bindings`.
-        Please reference ncmpcpp(1) (ncmpcpp's man page) to configure it accordingly, or consult
+        Please reference {manpage}`ncmpcpp(1)` to configure it accordingly, or consult
         [ncmpcpp's example bindings file](https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/bindings).
 
 

--- a/modules/collection/programs/obs-studio.nix
+++ b/modules/collection/programs/obs-studio.nix
@@ -15,8 +15,8 @@ in {
     package = mkPackageOption pkgs "obs-studio" {
       extraDescription = ''
         You can override the package to install plugins.
-
-        ```nix
+      '';
+      example = ''
         # OBS has a special "package" to wrap the obs-studio package with plugins
         package = pkgs.wrapOBS.override {
           # These plugins will get installed and wrapped into obs-studio for use
@@ -26,7 +26,6 @@ in {
             obs-websocket
           ];
         };
-        ```
       '';
     };
   };

--- a/modules/collection/programs/spotify-player.nix
+++ b/modules/collection/programs/spotify-player.nix
@@ -51,8 +51,10 @@ in {
         The configuration converted into TOML and written to
         {file}`$HOME/.config/spotify-player/app.toml`.
 
-        Please reference [spotify_player's configuration documentation](https://github.com/aome510/spotify-player/blob/master/docs/config.md#general)
+        Please reference [spotify_player's configuration documentation]
         for configuration options.
+
+        [spotify_player's configuration documentation]: https://github.com/aome510/spotify-player/blob/master/docs/config.md#general
       '';
     };
 
@@ -100,8 +102,10 @@ in {
         The theme converted into TOML and written to
         {file}`$HOME/.config/spotify-player/themes.toml`.
 
-        Please reference [spotify_player's theme documentation](https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes)
+        Please reference [spotify_player's theme documentation]
         for configuration options.
+
+        [spotify_player's theme documentation]: https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes
       '';
     };
 
@@ -127,8 +131,10 @@ in {
         {file}`$HOME/.config/spotify-player/keymap.toml`.
         See example for how to format declarations.
 
-        Please reference [spotify_player's keymaps documentation](https://github.com/aome510/spotify-player/blob/master/docs/config.md#keymaps)
+        Please reference [spotify_player's keymaps documentation]
         for more information.
+
+        [spotify_player's keymaps documentation]: https://github.com/aome510/spotify-player/blob/master/docs/config.md#keymaps
       '';
     };
   };

--- a/modules/collection/programs/spotify-player.nix
+++ b/modules/collection/programs/spotify-player.nix
@@ -19,8 +19,8 @@ in {
       extraDescription = ''
         You can use an override to configure certain settings
         baked into the package.
-
-        ```nix
+      '';
+      example = ''
         package = pkgs.spotify-player.override {
           # Useful overrides in the package
           withStreaming = true;
@@ -32,7 +32,6 @@ in {
           withSixel = true;
           withFuzzy = true;
         };
-        ```
       '';
     };
 

--- a/modules/collection/programs/spotify-player.nix
+++ b/modules/collection/programs/spotify-player.nix
@@ -50,7 +50,7 @@ in {
       };
       description = ''
         The configuration converted into TOML and written to
-        `${config.directory}/.config/spotify-player/app.toml`.
+        `''${config.directory}/.config/spotify-player/app.toml`.
 
         Please reference https://github.com/aome510/spotify-player/blob/master/docs/config.md#general
         for config options.
@@ -99,7 +99,7 @@ in {
       ];
       description = ''
         The theme converted into TOML and written to
-        `${config.directory}/.config/spotify-player/themes.toml`.
+        `''${config.directory}/.config/spotify-player/themes.toml`.
 
         Please reference https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes
         for config options.
@@ -125,7 +125,7 @@ in {
       };
       description = ''
         Sets of keymaps and actions converted into TOML and written to
-        `${config.directory}/.config/spotify-player/keymap.toml`.
+        `''${config.directory}/.config/spotify-player/keymap.toml`.
         See example for how to format declarations.
 
         Please reference https://github.com/aome510/spotify-player/blob/master/docs/config.md#keymaps

--- a/modules/collection/programs/spotify-player.nix
+++ b/modules/collection/programs/spotify-player.nix
@@ -50,7 +50,7 @@ in {
       };
       description = ''
         The configuration converted into TOML and written to
-        `''${config.directory}/.config/spotify-player/app.toml`.
+        {file}`$HOME/.config/spotify-player/app.toml`.
 
         Please reference https://github.com/aome510/spotify-player/blob/master/docs/config.md#general
         for config options.
@@ -99,7 +99,7 @@ in {
       ];
       description = ''
         The theme converted into TOML and written to
-        `''${config.directory}/.config/spotify-player/themes.toml`.
+        {file}`$HOME/.config/spotify-player/themes.toml`.
 
         Please reference https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes
         for config options.
@@ -125,7 +125,7 @@ in {
       };
       description = ''
         Sets of keymaps and actions converted into TOML and written to
-        `''${config.directory}/.config/spotify-player/keymap.toml`.
+        {file}`$HOME/.config/spotify-player/keymap.toml`.
         See example for how to format declarations.
 
         Please reference https://github.com/aome510/spotify-player/blob/master/docs/config.md#keymaps

--- a/modules/collection/programs/spotify-player.nix
+++ b/modules/collection/programs/spotify-player.nix
@@ -52,8 +52,8 @@ in {
         The configuration converted into TOML and written to
         {file}`$HOME/.config/spotify-player/app.toml`.
 
-        Please reference https://github.com/aome510/spotify-player/blob/master/docs/config.md#general
-        for config options.
+        Please reference [spotify_player's configuration documentation](https://github.com/aome510/spotify-player/blob/master/docs/config.md#general)
+        for configuration options.
       '';
     };
 
@@ -101,8 +101,8 @@ in {
         The theme converted into TOML and written to
         {file}`$HOME/.config/spotify-player/themes.toml`.
 
-        Please reference https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes
-        for config options.
+        Please reference [spotify_player's theme documentation](https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes)
+        for configuration options.
       '';
     };
 
@@ -128,7 +128,7 @@ in {
         {file}`$HOME/.config/spotify-player/keymap.toml`.
         See example for how to format declarations.
 
-        Please reference https://github.com/aome510/spotify-player/blob/master/docs/config.md#keymaps
+        Please reference [spotify_player's keymaps documentation](https://github.com/aome510/spotify-player/blob/master/docs/config.md#keymaps)
         for more information.
       '';
     };

--- a/modules/collection/programs/starship.nix
+++ b/modules/collection/programs/starship.nix
@@ -36,8 +36,8 @@ in {
 
       description = ''
         The configuration converted to TOML and written to {file}`$HOME/.config/starship.toml`.
-        Please reference [https://starship.rs/config](https://starship.rs/config)
-        for config options.
+        Please reference [Starship's documentation](https://starship.rs/config)
+        for configuration options.
       '';
     };
     integrations = {

--- a/modules/collection/programs/starship.nix
+++ b/modules/collection/programs/starship.nix
@@ -35,8 +35,9 @@ in {
       };
 
       description = ''
-        The configuration converted to TOML and written to `''${config.directory}/.config/starship.toml`.
-        Please reference https://starship.rs/config/ for config options.
+        The configuration converted to TOML and written to {file}`$HOME/.config/starship.toml`.
+        Please reference [https://starship.rs/config](https://starship.rs/config)
+        for config options.
       '';
     };
     integrations = {

--- a/modules/collection/programs/starship.nix
+++ b/modules/collection/programs/starship.nix
@@ -36,8 +36,9 @@ in {
 
       description = ''
         The configuration converted to TOML and written to {file}`$HOME/.config/starship.toml`.
-        Please reference [Starship's documentation](https://starship.rs/config)
-        for configuration options.
+        Please reference [Starship's documentation] for configuration options.
+
+        [Starship's documentation]: https://starship.rs/config
       '';
     };
     integrations = {

--- a/modules/collection/programs/starship.nix
+++ b/modules/collection/programs/starship.nix
@@ -33,6 +33,11 @@ in {
           error_symbol = "➜";
         };
       };
+
+      description = ''
+        The configuration converted to TOML and written to `''${config.directory}/.config/starship.toml`.
+        Please reference https://starship.rs/config/ for config options.
+      '';
     };
     integrations = {
       zsh.enable = mkOption {

--- a/modules/collection/programs/tofi.nix
+++ b/modules/collection/programs/tofi.nix
@@ -28,8 +28,8 @@ in {
       description = ''
         The configuration converted into "key = value" and written to
         {file}`$HOME/.config/tofi/config`.
-        Please reference [tofi(5) (manpage)](https://github.com/philj56/tofi/blob/master/doc/tofi.5.md),
-        or see an example at [https://github.com/philj56/tofi/blob/master/doc/config](https://github.com/philj56/tofi/blob/master/doc/config).
+        Please reference {manpage}`tofi(5)`,
+        or see an example at [tofi's default configuration](https://github.com/philj56/tofi/blob/master/doc/config).
       '';
     };
   };

--- a/modules/collection/programs/tofi.nix
+++ b/modules/collection/programs/tofi.nix
@@ -27,7 +27,7 @@ in {
       };
       description = ''
         The configuration converted into "key = value" and written to
-        `${config.directory}/.config/tofi/config`.
+        `''${config.directory}/.config/tofi/config`.
         Please reference tofi(5) (manpage) at https://github.com/philj56/tofi/blob/master/doc/tofi.5.md,
         or see an example at https://github.com/philj56/tofi/blob/master/doc/config.
       '';

--- a/modules/collection/programs/tofi.nix
+++ b/modules/collection/programs/tofi.nix
@@ -27,9 +27,9 @@ in {
       };
       description = ''
         The configuration converted into "key = value" and written to
-        `''${config.directory}/.config/tofi/config`.
-        Please reference tofi(5) (manpage) at https://github.com/philj56/tofi/blob/master/doc/tofi.5.md,
-        or see an example at https://github.com/philj56/tofi/blob/master/doc/config.
+        {file}`$HOME/.config/tofi/config`.
+        Please reference [tofi(5) (manpage)](https://github.com/philj56/tofi/blob/master/doc/tofi.5.md),
+        or see an example at [https://github.com/philj56/tofi/blob/master/doc/config](https://github.com/philj56/tofi/blob/master/doc/config).
       '';
     };
   };

--- a/modules/collection/programs/tofi.nix
+++ b/modules/collection/programs/tofi.nix
@@ -27,9 +27,11 @@ in {
       };
       description = ''
         The configuration converted into "key = value" and written to
-        {file}`$HOME/.config/tofi/config`.
-        Please reference {manpage}`tofi(5)`,
-        or see an example at [tofi's default configuration](https://github.com/philj56/tofi/blob/master/doc/config).
+        {file}`$HOME/.config/tofi/config`. Please reference
+        {manpage}`tofi(5)`, or see an example at
+        [tofi's default configuration].
+
+        [tofi's default configuration]: https://github.com/philj56/tofi/blob/master/doc/config
       '';
     };
   };

--- a/modules/collection/programs/vscode.nix
+++ b/modules/collection/programs/vscode.nix
@@ -29,8 +29,10 @@ in {
         The configuration converted into JSON and written to
         {file}`$HOME/.config/Code/User/settings.json`.
 
-        Please reference [Visual Studio Code's official documentation](https://code.visualstudio.com/docs/getstarted/settings#_settings-json-file)
+        Please reference [Visual Studio Code's official documentation]
         for more information.
+
+        [Visual Studio Code's official documentation]: https://code.visualstudio.com/docs/getstarted/settings#_settings-json-file
       '';
     };
   };

--- a/modules/collection/programs/vscode.nix
+++ b/modules/collection/programs/vscode.nix
@@ -29,8 +29,8 @@ in {
         The configuration converted into JSON and written to
         {file}`$HOME/.config/Code/User/settings.json`.
 
-        Please reference https://code.visualstudio.com/docs/getstarted/settings#_settings-json-file
-        for more info.
+        Please reference [Visual Studio Code's official documentation](https://code.visualstudio.com/docs/getstarted/settings#_settings-json-file)
+        for more information.
       '';
     };
   };

--- a/modules/collection/programs/vscode.nix
+++ b/modules/collection/programs/vscode.nix
@@ -27,7 +27,7 @@ in {
       };
       description = ''
         The configuration converted into JSON and written to
-        `''${config.directory}/.config/Code/User/settings.json`.
+        {file}`$HOME/.config/Code/User/settings.json`.
 
         Please reference https://code.visualstudio.com/docs/getstarted/settings#_settings-json-file
         for more info.

--- a/modules/collection/programs/vscode.nix
+++ b/modules/collection/programs/vscode.nix
@@ -27,7 +27,7 @@ in {
       };
       description = ''
         The configuration converted into JSON and written to
-        `${config.directory}/.config/Code/User/settings.json`.
+        `''${config.directory}/.config/Code/User/settings.json`.
 
         Please reference https://code.visualstudio.com/docs/getstarted/settings#_settings-json-file
         for more info.

--- a/modules/collection/programs/zsh.nix
+++ b/modules/collection/programs/zsh.nix
@@ -31,6 +31,8 @@
       default = "";
       description = ''
         Commands that will be added verbatim to ${configLocation}.
+
+        A good starting point for learning how to configure zsh is [the ArchWiki entry](https://wiki.archlinux.org/title/Zsh).
       '';
     };
 

--- a/modules/collection/programs/zsh.nix
+++ b/modules/collection/programs/zsh.nix
@@ -6,12 +6,11 @@
 }: let
   inherit (builtins) any attrValues filter;
   inherit (lib.attrsets) mapAttrsToList;
-  inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkRenamedOptionModule;
-  inherit (lib.options) literalExpression mkEnableOption mkPackageOption mkOption;
+  inherit (lib.options) literalExpression mkEnableOption mkOption mkPackageOption;
   inherit (lib.strings) concatStringsSep optionalString;
   inherit (lib.trivial) id;
-  inherit (lib.types) attrsOf listOf bool lines nullOr path submodule;
+  inherit (lib.types) attrsOf listOf lines nullOr path submodule;
 
   mkPlugins = plugins:
     concatStringsSep "\n"
@@ -31,7 +30,7 @@
       type = lines;
       default = "";
       description = ''
-        Commands that will be added verbatim to ${configLocation}.;
+        Commands that will be added verbatim to ${configLocation}.
       '';
     };
 
@@ -45,7 +44,7 @@ in {
     )
   ];
   options.rum.programs.zsh = {
-    enable = mkEnableOption "zsh module.";
+    enable = mkEnableOption "zsh";
     package = mkPackageOption pkgs "zsh" {};
     plugins = mkOption {
       type = attrsOf (submodule {

--- a/modules/collection/programs/zsh.nix
+++ b/modules/collection/programs/zsh.nix
@@ -32,7 +32,9 @@
       description = ''
         Commands that will be added verbatim to ${configLocation}.
 
-        A good starting point for learning how to configure zsh is [the ArchWiki entry](https://wiki.archlinux.org/title/Zsh).
+        A good starting point for learning how to configure zsh is the [Arch Wiki entry].
+
+        [Arch Wiki entry]: https://wiki.archlinux.org/title/Zsh
       '';
     };
 

--- a/modules/lib/generators/ncmpcpp.nix
+++ b/modules/lib/generators/ncmpcpp.nix
@@ -39,7 +39,9 @@ in {
           then "yes"
           else "no";
       }
-      .${typeOf value};
+      .${
+        typeOf value
+      };
   in
     concatStringsSep "\n" (mapAttrsToList (name: value: "${name} = ${convertValue value}") settings);
 }

--- a/modules/lib/types/hyprType.nix
+++ b/modules/lib/types/hyprType.nix
@@ -1,8 +1,18 @@
+# copied from https://github.com/hyprwm/Hyprland/blob/ff97d18c4c61ae14f8f3b80178e6b72c8a4b7901/nix/module.nix#L23-L38
 {lib}: let
-  inherit (lib.types) attrsOf listOf oneOf bool float int path str;
-
-  hyprValue = oneOf [str path bool int float hyprList hyprMap];
-  hyprMap = attrsOf hyprValue;
-  hyprList = listOf hyprValue;
+  inherit (lib.types) attrsOf listOf nullOr oneOf bool float int path str;
+  valueType =
+    nullOr (oneOf [
+      bool
+      int
+      float
+      str
+      path
+      (attrsOf valueType)
+      (listOf valueType)
+    ])
+    // {
+      description = "Hyprland configuration value";
+    };
 in
-  hyprMap
+  valueType


### PR DESCRIPTION
This PR adds support for documentation through the means of [ndg v2](https://github.com/feel-co/ndg/tree/v2). This PR is a draft as I have not been able to figure out *yet* how to generate a proper optionsJSON, as some attributes seem to be missing for a proper evaluation: 

```console
       error: attribute 'users' missing
       at /nix/store/z7hkn7gh9xjx2m4kaxz3a5rwzpyr122x-source/modules/nixos/default.nix:27:25:
           26|             user = config.users.users.${name}.name;
           27|             directory = config.users.users.${name}.home;
             |                         ^
           28|             clobberFiles = cfg.clobberByDefault;
```

Unsure how I could remedy to this. @NotAShelf could you please take a look at this and tell me what I'm doing wrong?