### PR TITLE
meta: autoinstall pre-commit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,9 @@
             python312Packages.mdformat-toc
             python312Packages.mdformat-gfm
           ];
+          shellHook = ''
+            pre-commit install
+          '';
         };
       }
     );


### PR DESCRIPTION
Some changes got lost while I was manipulating the commit history, notably autoinstalling pre-commit when entering the shell. This aims to add it back.