### PR TITLE
programs/starship: prefix starship under `rum`

### DIFF
--- a/modules/collection/programs/starship.nix
+++ b/modules/collection/programs/starship.nix
@@ -9,9 +9,9 @@
 
   toml = pkgs.formats.toml {};
 
-  cfg = config.programs.starship;
+  cfg = config.rum.programs.starship;
 in {
-  options.programs.starship = {
+  options.rum.programs.starship = {
     enable = mkEnableOption "starship module.";
     package = mkPackageOption pkgs "starship" {};
     settings = mkOption {


### PR DESCRIPTION
I don't know how I forgot to add it, but this was my fault. Starship was directly under `programs`, not `rum.programs`.