### PR TITLE
Add commit message  hook

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,20 @@
+[tool.commitizen]
+name = "cz_customize"
+
+[tool.commitizen.customize]
+message_template = "{{scope}}: {{message}}"
+example = "flake: add new input"
+schema = "<scope>: <message>"
+schema_pattern = "^[a-zA-Z]+(?:\\/[a-zA-Z]+)?:\\s.+$"
+commit_parser = "^(?P<scope>[a-z]+(?:\\/[a-z]+)?):\\s(?P<message>\\w.+)"
+
+# for interactive commits
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "scope"
+message = "Enter the scope (e.g., 'modules', 'programs/example'):"
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "message"
+message = "Enter the commit message (no punctuation at start):"

--- a/.cz.toml
+++ b/.cz.toml
@@ -2,17 +2,29 @@
 name = "cz_customize"
 
 [tool.commitizen.customize]
-message_template = "{{scope}}: {{message}}"
-example = "flake: add new input"
+message_template = "{{top_level_scope}}{% if specific_scope %}/{{specific_scope}}{% endif %}: {{message}}"
+example = "meta: add new input"
 schema = "<scope>: <message>"
-schema_pattern = "^[a-zA-Z]+(?:\\/[a-zA-Z]+)?:\\s.+$"
-commit_parser = "^(?P<scope>[a-z]+(?:\\/[a-z]+)?):\\s(?P<message>\\w.+)"
+schema_pattern = "^[a-z]+(?:\\/[a-zA-Z0-9_-]+)?:\\s.+$"
+commit_parser = "^(?P<scope>[a-z]+(?:\\/[a-zA-Z0-9_-]+)?):\\s(?P<message>\\w.+)"
 
-# for interactive commits
+[[tool.commitizen.customize.questions]]
+type = "list"
+name = "top_level_scope"
+message = "Choose the top-level scope in which your changes are going:"
+choices = [
+  {value = "programs", name = "programs: for modules that are programs (e.g. fish)"},
+  {value = "misc", name = "misc: for modules that aren't programs nor services (e.g. gtk)"},
+  {value = "lib", name = "lib: for new hjem-rum lib functions"},
+  {value = "meta", name = "meta: for repo related changes (e.g. formatting, adding a new commit hook...)"},
+  {value = "docs", name = "docs: for documentation purposes (e.g. adding the contributing guidelines"},
+  {value = "flake", name = "flake: for updates to the flake (e.g. add a new input)"}
+]
+
 [[tool.commitizen.customize.questions]]
 type = "input"
-name = "scope"
-message = "Enter the scope (e.g., 'modules', 'programs/example'):"
+name = "specific_scope"
+message = "Enter the optional specific scope under which your commit will go (e.g. foo for a program under programs/foo).:"
 
 [[tool.commitizen.customize.questions]]
 type = "input"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-
   - repo: local
     hooks:
       - id: nix-fmt
@@ -23,3 +22,10 @@ repos:
         language: system
         entry: mdformat
         files: .+\.md$
+
+      - id: commitizen
+        name: checks commit messages for our commit style
+        entry: cz
+        args: ["check", "--commit-msg-file"]
+        language: system
+        stages: [commit-msg]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Hjem was initially created as an improved implementation of the `home` functiona
 
 ## Setup
 
-> [!WARNING]
+> \[!WARNING\]
 > Importing Hjem Rum as a NixOS Module is being deprecated in favor of a Hjem Module. While this should not change user-side functionality, it does mean you will need to change where you import Hjem Rum in your config, and how you do so. If you were previously using Hjem Rum with the soon-to-be deprecated NixOS Module (importing it into `imports`), please see below on how to update to the Hjem Module. For more information on why this was done, see [#30](https://github.com/snugnug/hjem-rum/pull/30).
 
 To start using Hjem Rum, you must first import the flake and its modules into your system(s):

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,14 +1,20 @@
 # Contributing
 
-Hjem Rum (or HJR) is always in need of contributions as a module collection. As programs are developed, modules will need to be added, changed, removed, etc., meaning that the development of HJR is, in essence, unending.
+Hjem Rum (or HJR) is always in need of contributions as a module collection. As
+programs are developed, modules will need to be added, changed, removed, etc.,
+meaning that the development of HJR is, in essence, unending.
 
-Contributing is also a great way to learn the Nix module system and even function writing. Don't be afraid to experiment and try learning something new.
+Contributing is also a great way to learn the Nix module system and even
+function writing. Don't be afraid to experiment and try learning something new.
 
-If you are familiar with contributing to open source software, you can safely skip ahead to [Core Principles](#core-principles). Otherwise, read the following section to learn how to fork a repo and open a PR.
+If you are familiar with contributing to open source software, you can safely
+skip ahead to [Core Principles](#core-principles). Otherwise, read the following
+section to learn how to fork a repo and open a PR.
 
 <!-- mdformat-toc start --slug=github --maxlevel=6 --minlevel=2 -->
 
 - [Getting Started](#getting-started)
+  - [Commit format](#commit-format)
 - [Core Principles](#core-principles)
 - [Guidelines](#guidelines)
   - [Where to put a new module](#where-to-put-a-new-module)
@@ -24,19 +30,57 @@ If you are familiar with contributing to open source software, you can safely sk
 
 ## Getting Started<a name="getting-started"></a>
 
-To begin contributing to HJR, you will first need to create a fork off of the main branch in order to make changes. For info on how to do this, we recommend GitHub's own [documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo).
+To begin contributing to HJR, you will first need to create a fork off of the
+main branch in order to make changes. For info on how to do this, we recommend
+GitHub's own
+[documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo).
 
-Once you have your own fork, it is recommend that you create a branch for the changes or additions you seek to make, to make it easier to set up multiple PRs from your fork. To do so, you can read this [article](https://www.geeksforgeeks.org/how-to-create-a-new-branch-in-git/) that will also explain branches for you. Don't worry too much about the technical details, the most important thing is to make and switch to a branch from HEAD.
+Once you have your own fork, it is recommend that you create a branch for the
+changes or additions you seek to make, to make it easier to set up multiple PRs
+from your fork. To do so, you can read this
+[article](https://www.geeksforgeeks.org/how-to-create-a-new-branch-in-git/) that
+will also explain branches for you. Don't worry too much about the technical
+details, the most important thing is to make and switch to a branch from HEAD.
 
-You can now make your changes in your editor of choice. After committing your changes, you can run:
+### Commit format<a name="commit-format"></a>
+
+> \[!INFO\]
+> Our dev shell allows for interactive commits, through the means of
+> [commitizen](https://github.com/commitizen-tools/commitizen). If this is
+> preferred, you can run `cz commit` to be prompted to build your commit.
+
+For consistency, we do enforce a strict (but simple) commit style, that will be
+linted against. The format is as follows:
+
+```console
+<top_level_scope>/[<specific_scope>]: <message>
+
+<body>
+```
+
+- \<scope>: the scope of your commit (e.g. if making a change to a module, this
+  would be `programs/foot`). We do enforce a two scope level limit, so
+  `modules/programs/foot` will not work. For anything else, we tend to use
+  semantic scopes such as `meta` for CI/repo related changes.
+
+- \<message>: A free form commit message. Having a commit body is encouraged
+  when your changes are difficult to explain, unless you're writing in-depth
+  code comments (it is still preferred however).
+
+You can now make your changes in your editor of choice. After committing your
+changes, you can run:
 
 ```shell
 git push origin <branch-name>
 ```
 
-and then open up a PR, or "Pull Request," in the upstream HJR repository. Again, GitHub has good documentation for [this](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
+and then open up a PR, or "Pull Request," in the upstream HJR repository. Again,
+GitHub has good documentation for
+[this](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
 
-After you have setup a PR, it will be [reviewed](#reviewing-a-pr) by maintainers and changes may be requested. Make the changes requested and eventually it will likely be accepted and merged into main.
+After you have setup a PR, it will be [reviewed](#reviewing-a-pr) by maintainers
+and changes may be requested. Make the changes requested and eventually it will
+likely be accepted and merged into main.
 
 ## Core Principles<a name="core-principles"></a>
 
@@ -46,11 +90,14 @@ In creating HJR, we had a few principles in mind for development:
 1. Include only the module collection - leave functionality to Hjem; and
 1. Maintain readability of code, even for new users.
 
-Please keep these in mind as you read through our general guidelines for contributing.
+Please keep these in mind as you read through our general guidelines for
+contributing.
 
 ## Guidelines<a name="guidelines"></a>
 
-These guidelines, are, of course, merely guidelines. There are and will continue to be exceptions. However, do your best to stick to them, and keep in mind that reviewers will hold you to them as much as possible.
+These guidelines, are, of course, merely guidelines. There are and will continue
+to be exceptions. However, do your best to stick to them, and keep in mind that
+reviewers will hold you to them as much as possible.
 
 ### Where to put a new module<a name="where-to-put-a-new-module"></a>
 
@@ -58,7 +105,10 @@ WIP
 
 ### Aliases<a name="aliases"></a>
 
-At the top of any module, there should always be a `let ... in` set. Within this, functions should have their location aliased, cfg should be aliased, and any generators should have an alias as well. Here's an example for a module that makes use of the TOML generator used in nixpkgs:
+At the top of any module, there should always be a `let ... in` set. Within
+this, functions should have their location aliased, cfg should be aliased, and
+any generators should have an alias as well. Here's an example for a module that
+makes use of the TOML generator used in nixpkgs:
 
 ```nix
 {
@@ -79,24 +129,39 @@ in {
   options.rum.programs.alacritty = {
 ```
 
-Notice that each function has its location aliased with an inherit to its target location. Ideally, this location should be where one could find it in the source code. For example, rather than using `lib.mkIf`, we use `lib.modules.mkIf`, because mkIf is declared at `lib/modules.nix` within the nixpkgs repo.
+Notice that each function has its location aliased with an inherit to its target
+location. Ideally, this location should be where one could find it in the source
+code. For example, rather than using `lib.mkIf`, we use `lib.modules.mkIf`,
+because mkIf is declared at `lib/modules.nix` within the nixpkgs repo.
 
-Also notice that in this case, `pkgs.formats.toml {}` includes both `generate` and `type`, so the alias name is just `toml`.
+Also notice that in this case, `pkgs.formats.toml {}` includes both `generate`
+and `type`, so the alias name is just `toml`.
 
-Always be sure to include `cfg` that links to the point where options are configured by the user.
+Always be sure to include `cfg` that links to the point where options are
+configured by the user.
 
 ### Writing Options<a name="writing-options"></a>
 
-Writing new options is the core of any new module. It is also the easiest place to blunder. As stated above, a core principle of HJR is to minimize the number of options as much as possible. As such, we have created a general template that should help inform you of what options are needed and what are not:
+Writing new options is the core of any new module. It is also the easiest place
+to blunder. As stated above, a core principle of HJR is to minimize the number
+of options as much as possible. As such, we have created a general template that
+should help inform you of what options are needed and what are not:
 
 - `enable`: Used to toggle install and configuration of package(s).
 - `package`: Used to customize and override the package installed.
   - As needed, `packages`: List of packages used in a module.
-- `settings`: Primary configuration option, takes Nix code and converts to target lang.
-  - As needed, one extra option for each extra file, such as `theme` for theme.toml.
-- As needed, `extraConfig`: Extra lines of strings passed directly to config file for certain programs.
+- `settings`: Primary configuration option, takes Nix code and converts to
+  target lang.
+  - As needed, one extra option for each extra file, such as `theme` for
+    theme.toml.
+- As needed, `extraConfig`: Extra lines of strings passed directly to config
+  file for certain programs.
 
-For the most part, this should be sufficient. Overrides of packages should be simply offered through a direct override in `package`. For example, ncmpcpp's package has a `withVisualizer ? false` argument. Rather than creating an extra option for this, the contributor should note this with `extraDescription` like so:
+For the most part, this should be sufficient. Overrides of packages should be
+simply offered through a direct override in `package`. For example, ncmpcpp's
+package has a `withVisualizer ? false` argument. Rather than creating an extra
+option for this, the contributor should note this with `extraDescription` like
+so:
 
 ```nix
 options.rum.programs.ncmpcpp = {
@@ -121,9 +186,18 @@ config.hjem.users.<username>.rum.programs.ncmpcpp = {
 };
 ```
 
-The `type` of `settings` and other conversion options should preferably be a `type` option exposed by the generator (for example, TOML has `pkgs.formats.toml {}.type` and `pkgs.formats.toml {}.generate`), or, if using a custom generator, a `type` should be created in `lib/types/` (for example, `hyprType`). Otherwise, a simple `attrsOf anything` would suffice.
+The `type` of `settings` and other conversion options should preferably be a
+`type` option exposed by the generator (for example, TOML has
+`pkgs.formats.toml {}.type` and `pkgs.formats.toml {}.generate`), or, if using a
+custom generator, a `type` should be created in `lib/types/` (for example,
+`hyprType`). Otherwise, a simple `attrsOf anything` would suffice.
 
-As a rule of thumb, submodules should not be employed. Instead, there should only be one option per file. For some files, such as spotify-player's `keymap.toml`, you may be tempted to create multiple options for `actions` and `keymaps`, as Home Manager does. Please avoid this. In this case, we can have a simple `keymap` option that the user can then include a list of keymaps and/or a list of actions that get propagated accordingly:
+As a rule of thumb, submodules should not be employed. Instead, there should
+only be one option per file. For some files, such as spotify-player's
+`keymap.toml`, you may be tempted to create multiple options for `actions` and
+`keymaps`, as Home Manager does. Please avoid this. In this case, we can have a
+simple `keymap` option that the user can then include a list of keymaps and/or a
+list of actions that get propagated accordingly:
 
 ```nix
   keymap = mkOption {
@@ -154,7 +228,8 @@ As a rule of thumb, submodules should not be employed. Instead, there should onl
   };
 ```
 
-Also note that the option description includes a link to upstream info on settings options.
+Also note that the option description includes a link to upstream info on
+settings options.
 
 ### Conditional Config<a name="conditional-config"></a>
 
@@ -166,7 +241,10 @@ config = mkIf cfg.enable {
 };
 ```
 
-As a general guideline, **do not write empty strings to files**. Not only is this poorly optimized, but it will cause issues if a user happens to be manually using the Hjem tooling alongside HJR. Here are some examples of how you might avoid this:
+As a general guideline, **do not write empty strings to files**. Not only is
+this poorly optimized, but it will cause issues if a user happens to be manually
+using the Hjem tooling alongside HJR. Here are some examples of how you might
+avoid this:
 
 ```nix
 config = mkIf cfg.enable {
@@ -177,7 +255,9 @@ config = mkIf cfg.enable {
 };
 ```
 
-Here all that is needed is a simple `mkIf` with a condition of the `settings` option not being left empty. In a case where you write to multiple files, you can use `optionalAttrs`, like so:
+Here all that is needed is a simple `mkIf` with a condition of the `settings`
+option not being left empty. In a case where you write to multiple files, you
+can use `optionalAttrs`, like so:
 
 ```nix
 files = (
@@ -195,9 +275,13 @@ files = (
 );
 ```
 
-This essentially takes the attrset of `files` and _optionally_ adds attributes defining more files to be written to _if_ the corresponding option has been set. This is optimal because the first three files written to share an option due to how GTK configuration works.
+This essentially takes the attrset of `files` and _optionally_ adds attributes
+defining more files to be written to _if_ the corresponding option has been set.
+This is optimal because the first three files written to share an option due to
+how GTK configuration works.
 
-One last case is in the Hyprland, where several checks and several options are needed to compile into one file. Here is how it is done:
+One last case is in the Hyprland, where several checks and several options are
+needed to compile into one file. Here is how it is done:
 
 ```nix
 files = let
@@ -251,23 +335,41 @@ in {
 };
 ```
 
-An additional attrset of boolean aliases is set within a `let ... in` set to highlight the different checks done and to add qucik ways to reference each check without excess and redudant code.
+An additional attrset of boolean aliases is set within a `let ... in` set to
+highlight the different checks done and to add qucik ways to reference each
+check without excess and redudant code.
 
-First, the file is only written if any of the options to write to the file are set. `optionalString` is then used to compile each option's results in an optimized and clean way.
+First, the file is only written if any of the options to write to the file are
+set. `optionalString` is then used to compile each option's results in an
+optimized and clean way.
 
 ### Extending Lib<a name="extending-lib"></a>
 
-Rather than having functions scattered throughout the module collection, we would rather keep our directories organized and purposeful. Therefore, all custom functions should go into our extended lib, found at `modules/lib/`.
+Rather than having functions scattered throughout the module collection, we
+would rather keep our directories organized and purposeful. Therefore, all
+custom functions should go into our extended lib, found at `modules/lib/`.
 
-The most common functions that might be created are a `generator` and `type` pair. The former should be prefixed with "to" to maintain style and describe their function: conversion _to_ other formats. For example, `toNcmpcppSettings` is the function that converts to the format required for ncmpcpp settings.
+The most common functions that might be created are a `generator` and `type`
+pair. The former should be prefixed with "to" to maintain style and describe
+their function: conversion _to_ other formats. For example, `toNcmpcppSettings`
+is the function that converts to the format required for ncmpcpp settings.
 
-Likewise, types should be suffixed with "Type" to maintain style and describe their function. For example, `hyprType` describes the type used in `settings` converted to hyprlang.
+Likewise, types should be suffixed with "Type" to maintain style and describe
+their function. For example, `hyprType` describes the type used in `settings`
+converted to hyprlang.
 
-When it comes to directory structure, you should be able to infer how we organize our lib by both our folder structure itself as well as the names of functions. For example, `lib.rum.types.gtkType` is found in `lib/types/gtkType.nix`. In cases where a file is a single function, always be sure to make sure the name matches the file.
+When it comes to directory structure, you should be able to infer how we
+organize our lib by both our folder structure itself as well as the names of
+functions. For example, `lib.rum.types.gtkType` is found in
+`lib/types/gtkType.nix`. In cases where a file is a single function, always be
+sure to make sure the name matches the file.
 
-If a program uses multiple functions of the same kind (e.g. two generators), you can put them in one file, like is done in `lib/generators/gtk.nix`.
+If a program uses multiple functions of the same kind (e.g. two generators), you
+can put them in one file, like is done in `lib/generators/gtk.nix`.
 
-Additionally, please follow how lib is structured in nixpkgs. For example, the custom function `attrsNamesHasPrefix` is under `attrsets` to signify that it operates on an attrset, just like in nixpkgs.
+Additionally, please follow how lib is structured in nixpkgs. For example, the
+custom function `attrsNamesHasPrefix` is under `attrsets` to signify that it
+operates on an attrset, just like in nixpkgs.
 
 ### Docs<a name="docs"></a>
 
@@ -279,4 +381,8 @@ WIP
 
 ## Reviewing a PR<a name="reviewing-a-pr"></a>
 
-Even if you do not have write-access. You can always leave a review on someone else's PR. Again, GitHub has great [documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request) on doing so. This is great practice for learning the guidelines as well as learning exceptions to the rules.
+Even if you do not have write-access. You can always leave a review on someone
+else's PR. Again, GitHub has great
+[documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request)
+on doing so. This is great practice for learning the guidelines as well as
+learning exceptions to the rules.

--- a/flake.nix
+++ b/flake.nix
@@ -42,9 +42,10 @@
             python312Packages.mdformat-toc
             python312Packages.mdformat-gfm
             self.formatter.${system}
+            python312Packages.commitizen
           ];
           shellHook = ''
-            pre-commit install
+            pre-commit install --hook-type pre-commit --hook-type commit-msg --hook-type pre-push
           '';
         };
       }


### PR DESCRIPTION
This PR adds linting to our commits through the means of [commitizen](https://github.com/commitizen-tools/commitizen/).

The format enforced can be found in `docs/CONTRIBUTING.md`:

```console
<scope>: <message>

<body>
```