### PR TITLE
chore: add formatter to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
             python312Packages.mdformat-footnote
             python312Packages.mdformat-toc
             python312Packages.mdformat-gfm
+            self.formatter.${system}
           ];
           shellHook = ''
             pre-commit install


### PR DESCRIPTION
Simple thing I forgot to add, having our formatter in the devshell.