### PR TITLE
Move `zsh.integrations.starship` into `starship.integrations.zsh`

### DIFF
--- a/modules/collection/programs/zsh.nix
+++ b/modules/collection/programs/zsh.nix
@@ -7,7 +7,7 @@
   inherit (builtins) any attrValues filter;
   inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.meta) getExe;
-  inherit (lib.modules) mkIf;
+  inherit (lib.modules) mkIf mkRenamedOptionModule;
   inherit (lib.options) literalExpression mkEnableOption mkPackageOption mkOption;
   inherit (lib.strings) concatStringsSep optionalString;
   inherit (lib.trivial) id;
@@ -37,6 +37,13 @@
 
   cfg = config.rum.programs.zsh;
 in {
+  imports = [
+    (
+      mkRenamedOptionModule
+      ["rum" "programs" "zsh" "integrations" "starship" "enable"]
+      ["rum" "programs" "starship" "integrations" "zsh" "enable"]
+    )
+  ];
   options.rum.programs.zsh = {
     enable = mkEnableOption "zsh module.";
     package = mkPackageOption pkgs "zsh" {};
@@ -66,14 +73,6 @@ in {
         done at this level, for the sake of organization.
       '';
     };
-    integrations = {
-      starship.enable = mkOption {
-        type = bool;
-        default = config.rum.programs.starship.enable;
-        example = true;
-        description = "Whether to enable starship integration.";
-      };
-    };
     initConfig = mkShellConfigOption "{file}`.zshrc`";
     loginConfig = mkShellConfigOption "{file}`.zlogin`";
     logoutConfig = mkShellConfigOption "{file}`.zlogout`";
@@ -95,8 +94,6 @@ in {
         (
           optionalString check.plugins (mkPlugins cfg.plugins)
           + optionalString check.initConfig cfg.initConfig
-          + optionalString cfg.integrations.starship.enable
-          ''eval "$(${getExe config.rum.programs.starship.package} init zsh)"''
         );
     };
   };


### PR DESCRIPTION
As per what I talked about in #42. 

An important thing to take into consideration is that the global `integrations.enable` should be overrideable on a specific basis (if we want it for a specific shell and we might not want it for another, in the case of starship). The new architecture actually makes this trivial, as we can make the specific integrations take the value of `cfg.integrations.enable` by default.

We then only have to check for the value of the specific boolean, as `default` pretty much takes care of the logic for us, without convoluted boolean logic.