### PR TITLE
programs/fish: add description to plugins option

### DIFF
--- a/modules/collection/programs/fish.nix
+++ b/modules/collection/programs/fish.nix
@@ -124,6 +124,28 @@ in {
     plugins = mkOption {
       type = attrsOf path;
       default = {};
+      description = ''
+        An attrset of plugins.
+
+        In the case where a plugin is a 'vendored' plugin, all we are doing is adding that
+        plugin to `hjem.users.<name>.packages`. As fish automatically discovers those files.
+
+        A vendored plugin is denoted by the existence of one of the following files in its derivation:
+        - /share/fish/vendor_conf.d
+        - /share/fish/vendor_completions.d
+        - /share/fish/vendor_functions.d
+
+        This will be the case with plugins present in `pkgs.fishPlugins`.
+
+        For the remaining cases, a file will be created at `~/.config/fish/conf.d/rum-plugin-<name>.fish`.
+        It will attempt to handle or source a variety of expected files from the derivation. Those files are:
+
+        - `/functions`: is added to `fish_function_path`
+        - `/completions`: is added to `fish_complete_path`
+        - `/conf.d/*`, `/key_bindings.fish`, `/init.fish`: sourced in this order
+
+        If a plugin seems to not work, verify that it contains one of the aformentioned files.
+      '';
       example = literalExample ''
         {
           inherit (pkgs.fishPlugins) z;


### PR DESCRIPTION
Turns out documentation is helpful. The description ended up a bit more detailed, hope that its still fine