### PR TITLE
programs: Add extraDescription for useful overrides

### DIFF
--- a/modules/collection/programs/ghostty.nix
+++ b/modules/collection/programs/ghostty.nix
@@ -32,7 +32,17 @@ in {
   options.rum.programs.ghostty = {
     enable = mkEnableOption "Ghostty";
 
-    package = mkPackageOption pkgs "ghostty" {};
+    package = mkPackageOption pkgs "ghostty" {
+      extraDescription = ''
+        You can use an override to configure some settings baked into the package.
+
+        ```nix
+        package = pkgs.ghostty.override {
+          withAdwaita = true;
+        };
+        ```
+      '';
+    };
 
     settings = mkOption {
       type = keyValue.type;

--- a/modules/collection/programs/ncmpcpp.nix
+++ b/modules/collection/programs/ncmpcpp.nix
@@ -14,14 +14,21 @@
   cfg = config.rum.programs.ncmpcpp;
 in {
   options.rum.programs.ncmpcpp = {
-    enable = mkEnableOption ''
-      Enables the rum module for ncmpcpp, a mpd-based music player.
-    '';
+    enable = mkEnableOption "ncmpcpp, a mpd-based music player.";
 
     package = mkPackageOption pkgs "ncmpcpp" {
       extraDescription = ''
-        You can use an override to toggle certain features like the visualizer, a clock screen, and more.
-               Please check out the package source for a complete list.
+        You can override the package to customize certain settings that are baked into the package.
+
+        ```nix
+        package = pkgs.ncmpccpp.override {
+          # useful overrides in the package
+          outputsSupport = true; # outputs screen
+          visualizerSupport = false; # visualizer screen
+          clockSupport = true; # clock screen
+          taglibSupport = true; # tag editor
+        };
+        ```
       '';
     };
 

--- a/modules/collection/programs/obs-studio.nix
+++ b/modules/collection/programs/obs-studio.nix
@@ -5,35 +5,33 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
-  inherit (lib.types) listOf package;
+  inherit (lib.options) mkEnableOption mkPackageOption;
 
   cfg = config.rum.programs.obs-studio;
 in {
   options.rum.programs.obs-studio = {
     enable = mkEnableOption "OBS Studio";
 
-    package = mkPackageOption pkgs "obs-studio" {};
+    package = mkPackageOption pkgs "obs-studio" {
+      extraDescription = ''
+        You can override the package to install plugins.
 
-    plugins = mkOption {
-      type = listOf package;
-      default = [];
-      example = [
-        pkgs.obs-studio-plugins.wlrobs #for screen capture w/wayland
-        pkgs.obs-studio-plugins.obs-vkcapture #vulkan/opengl game capture
-      ];
-      description = ''
-        A list of plugins the obs-studio package will be wrapped with.
-        Set of plugins available in nixpkgs under the obs-studio-plugins set.
+        ```nix
+        # OBS has a special "package" to wrap the obs-studio package with plugins
+        package = pkgs.wrapOBS.override {
+          # These plugins will get installed and wrapped into obs-studio for use
+          plugins = with pkgs.obs-studio-plugins; [
+            wlrobs
+            waveform
+            obs-websocket
+          ];
+        };
+        ```
       '';
     };
   };
 
   config = mkIf cfg.enable {
-    packages = [
-      (pkgs.wrapOBS.override {obs-studio = cfg.package;} {
-        plugins = cfg.plugins;
-      })
-    ];
+    packages = [cfg.package];
   };
 }

--- a/modules/collection/programs/spotify-player.nix
+++ b/modules/collection/programs/spotify-player.nix
@@ -15,7 +15,26 @@ in {
   options.rum.programs.spotify-player = {
     enable = mkEnableOption "spotify_player";
 
-    package = mkPackageOption pkgs "spotify-player" {};
+    package = mkPackageOption pkgs "spotify-player" {
+      extraDescription = ''
+        You can use an override to configure certain settings
+        baked into the package.
+
+        ```nix
+        package = pkgs.spotify-player.override {
+          # Useful overrides in the package
+          withStreaming = true;
+          withDaemon = true;
+          withAudioBackend = "rodio"; # alsa, pulseaudio, rodio, portaudio, jackaudio, rodiojack, sdl
+          withMediaControl = true;
+          withImage = true;
+          withNotify = true;
+          withSixel = true;
+          withFuzzy = true;
+        };
+        ```
+      '';
+    };
 
     settings = mkOption {
       type = toml.type;


### PR DESCRIPTION
See title. Package options for programs that have useful overrides should now have codeboxes with useful overrides that also serves to show how to use overrides with HJR.

Let me know if I missed any.