### PR TITLE
docs/CONTRIBUTING: convert links to reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # Hjem Rum
 
-A module collection for managing your `$HOME` with
-[Hjem](https://github.com/feel-co/hjem).
+[Hjem]: https://github.com/feel-co/hjem
+[contributing guidelines]: ./docs/CONTRIBUTING.md
+[license]: LICENSE
+[programs/fish]: modules/collection/programs/fish.nix
+[programs/zsh]: modules/collection/programs/zsh.nix
+[programs/hyprland]: modules/collection/programs/hyprland.nix
+[#17]: https://github.com/snugnug/hjem-rum/issues/17
+[#30]: https://github.com/snugnug/hjem-rum/pull/30
+[@eclairevoyant]: https://github.com/eclairevoyant
+[@NotAShelf]: https://github.com/NotAShelf
+
+A module collection for managing your `$HOME` with [Hjem].
 
 ## A brief explanation
 
@@ -32,8 +42,7 @@ provides, allowing you to simply install and config a program.
 > will need to change where you import Hjem Rum in your config, and how you do
 > so. If you were previously using Hjem Rum with the soon-to-be deprecated NixOS
 > Module (importing it into `imports`), please see below on how to update to the
-> Hjem Module. For more information on why this was done, see
-> [#30](https://github.com/snugnug/hjem-rum/pull/30).
+> Hjem Module. For more information on why this was done, see [#30].
 
 To start using Hjem Rum, you must first import the flake and its modules into
 your system(s):
@@ -121,31 +130,43 @@ hjem.users.<username>.rum.programs.alacritty = {
 
 ## Environmental Variables
 
-Hjem provides attribute set "environment.sessionVariables" that allows the user to set environmental variables to be sourced. However, Hjem does not have the capability to actually source them. This can be done manually, which is what Hjem Rum tries to do.
+Hjem provides attribute set "environment.sessionVariables" that allows the user
+to set environmental variables to be sourced. However, Hjem does not have the
+capability to actually source them. This can be done manually, which is what
+Hjem Rum tries to do.
 
-Currently, some of our modules may add environmental variables (such as our GTK module), but cannot load them without the use of another module. Currently, modules that load environmental variables include:
+Currently, some of our modules may add environmental variables (such as our GTK
+module), but cannot load them without the use of another module. Currently,
+modules that load environmental variables include:
 
-- [fish](modules/collection/programs/fish.nix)
-- [zsh](modules/collection/programs/zsh.nix)
-- [hyprland](modules/collection/programs/hyprland.nix)
+- [programs/fish]
+- [programs/zsh]
+- [programs/hyprland]
 
-If you are either using something like our GTK module, or are manually adding variables to environment.sessionVariables, but are neither loading those variables manually, or using one of the above modules, those variables will not be loaded, and may cause unintended problems. For example, GTK applications may not respect your theme, as some rely on the environmental variable to actually use the theme you declare.
+If you are either using something like our GTK module, or are manually adding
+variables to `environment.sessionVariables`, but are neither loading those
+variables manually, or using one of the above modules, those variables will not
+be loaded, and may cause unintended problems. For example, GTK applications may
+not respect your theme, as some rely on the environmental variable to actually
+use the theme you declare.
 
-Please see [#17](https://github.com/snugnug/hjem-rum/issues/17) for status on providing support for shells and compositors. If your shell or compositor is on listed there, please leave a comment and it will be added. You are encouraged to open a PR to help support your shell or compositor if possible.
+Please see [#17] for status on providing support for shells and compositors. If
+your shell or compositor is on listed there, please leave a comment and it will
+be added. You are encouraged to open a PR to help support your shell or
+compositor if possible.
 
 ## Contributing
 
-Hjem Rum is always in need of contribution. Please see
-[CONTRIBUTING.md](./docs/CONTRIBUTING.md) for more information on how to
-contribute and our guidelines.
+Hjem Rum is always in need of contribution. Please see our
+[contributing guidelines] for more information on how to contribute and our
+guidelines.
 
 ## Credits
 
-Credit goes to [@NotAShelf](https://github.com/NotAShelf) and
-[@éclairevoyant](https://github.com/eclairevoyant) for creating Hjem.
+Credit goes to [@NotAShelf] and [@eclairevoyant] for creating Hjem.
 
 ## License
 
 All the code within this repository is protected under the GPLv3 license unless
-explicitly stated otherwise within a file. Please see [LICENSE](LICENSE) for
-more information.
+explicitly stated otherwise within a file. Please see [LICENSE] for more
+information.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,5 +1,12 @@
 # Contributing
 
+[commitizen]: https://github.com/commitizen-tools/commitizen
+[article from GeeksforGeeks]: https://www.geeksforgeeks.org/how-to-create-a-new-branch-in-git/
+[creating a PR]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+[documentation on forking repositories]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
+[documentation on reviewing PRs]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request
+[Core Principles]: #core-principles
+
 Hjem Rum (or HJR) is always in need of contributions as a module collection. As
 programs are developed, modules will need to be added, changed, removed, etc.,
 meaning that the development of HJR is, in essence, unending.
@@ -8,29 +15,27 @@ Contributing is also a great way to learn the Nix module system and even
 function writing. Don't be afraid to experiment and try learning something new.
 
 If you are familiar with contributing to open source software, you can safely
-skip ahead to [Core Principles](#core-principles). Otherwise, read the following
-section to learn how to fork a repo and open a PR.
+skip ahead to [Core Principles]. Otherwise, read the following section to learn
+how to fork a repo and open a PR.
 
-## Getting Started<a name="getting-started"></a>
+## Getting Started
 
 To begin contributing to HJR, you will first need to create a fork off of the
 main branch in order to make changes. For info on how to do this, we recommend
-GitHub's own
-[documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo).
+GitHub's own [documentation on forking repositories].
 
 Once you have your own fork, it is recommend that you create a branch for the
 changes or additions you seek to make, to make it easier to set up multiple PRs
-from your fork. To do so, you can read this
-[article](https://www.geeksforgeeks.org/how-to-create-a-new-branch-in-git/) that
+from your fork. To do so, you can read this [article from GeeksforGeeks] that
 will also explain branches for you. Don't worry too much about the technical
 details, the most important thing is to make and switch to a branch from HEAD.
 
-### Commit format<a name="commit-format"></a>
+### Commit format
 
-> [!INFO]
+> [!TIP]
 > Our dev shell allows for interactive commits, through the means of
-> [commitizen](https://github.com/commitizen-tools/commitizen). If this is
-> preferred, you can run `cz commit` to be prompted to build your commit.
+> [commitizen]. If this is preferred, you can run `cz commit` to be prompted to
+> build your commit.
 
 For consistency, we do enforce a strict (but simple) commit style, that will be
 linted against. The format is as follows (sections between `[]` are optional):
@@ -45,13 +50,13 @@ linted against. The format is as follows (sections between `[]` are optional):
   program, this would be `programs`). For changes unrelated to the modules API,
   we tend to use semantic scopes such as `meta` for CI/repo related changes.
 
-- \[\<specific_scope>\]: An optional, more specific scope for your module. If
+- \[\<specific_scope>]: An optional, more specific scope for your module. If
   making changes to a specific program, this would be `programs/foot`.
 
 - \<message>: A free form commit message. Needs to be imperative and without
   punctuation (e.g. `do stuff` instead of `did stuff.`).
 
-- \[\<body>\]: A free form commit body. Having one is encouraged when your
+- \[\<body>]: A free form commit body. Having one is encouraged when your
   changes are difficult to explain, unless you're writing in-depth code comments
   (it is still preferred however).
 
@@ -63,14 +68,13 @@ git push origin <branch-name>
 ```
 
 and then open up a PR, or "Pull Request," in the upstream HJR repository. Again,
-GitHub has good documentation for
-[this](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
+GitHub has good documentation for [creating a PR].
 
 After you have setup a PR, it will be [reviewed](#reviewing-a-pr) by maintainers
 and changes may be requested. Make the changes requested and eventually it will
 likely be accepted and merged into main.
 
-## Core Principles<a name="core-principles"></a>
+## Core Principles
 
 In creating HJR, we had a few principles in mind for development:
 
@@ -81,17 +85,17 @@ In creating HJR, we had a few principles in mind for development:
 Please keep these in mind as you read through our general guidelines for
 contributing.
 
-## Guidelines<a name="guidelines"></a>
+## Guidelines
 
 These guidelines, are, of course, merely guidelines. There are and will continue
 to be exceptions. However, do your best to stick to them, and keep in mind that
 reviewers will hold you to them as much as possible.
 
-### Where to put a new module<a name="where-to-put-a-new-module"></a>
+### Where to put a new module
 
 WIP
 
-### Aliases<a name="aliases"></a>
+### Aliases
 
 At the top of any module, there should always be a `let ... in` set. Within
 this, functions should have their location aliased, cfg should be aliased, and
@@ -128,7 +132,7 @@ and `type`, so the alias name is just `toml`.
 Always be sure to include `cfg` that links to the point where options are
 configured by the user.
 
-### Writing Options<a name="writing-options"></a>
+### Writing Options
 
 Writing new options is the core of any new module. It is also the easiest place
 to blunder. As stated above, a core principle of HJR is to minimize the number
@@ -219,7 +223,7 @@ list of actions that get propagated accordingly:
 Also note that the option description includes a link to upstream info on
 settings options.
 
-### Conditional Config<a name="conditional-config"></a>
+### Conditional Config
 
 Always use a `mkIf` before the config section. Example:
 
@@ -331,7 +335,7 @@ First, the file is only written if any of the options to write to the file are
 set. `optionalString` is then used to compile each option's results in an
 optimized and clean way.
 
-### Extending Lib<a name="extending-lib"></a>
+### Extending Lib
 
 Rather than having functions scattered throughout the module collection, we
 would rather keep our directories organized and purposeful. Therefore, all
@@ -359,18 +363,17 @@ Additionally, please follow how lib is structured in nixpkgs. For example, the
 custom function `attrsNamesHasPrefix` is under `attrsets` to signify that it
 operates on an attrset, just like in nixpkgs.
 
-### Docs<a name="docs"></a>
+### Docs
 
 WIP
 
-### Tests<a name="tests"></a>
+### Tests
 
 WIP
 
-## Reviewing a PR<a name="reviewing-a-pr"></a>
+## Reviewing a PR
 
-Even if you do not have write-access. You can always leave a review on someone
-else's PR. Again, GitHub has great
-[documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request)
-on doing so. This is great practice for learning the guidelines as well as
-learning exceptions to the rules.
+Even if you do not have write-access, you can always leave a review on someone
+else's PR. Again, GitHub has great [documentation on reviewing PRs]. This is
+great practice for learning the guidelines as well as learning exceptions to the
+rules.


### PR DESCRIPTION
This is a simple housekeeping PR, based on @nydragon's idea. GFM has supports for [reference links](https://github.github.com/gfm/#reference-link), which allows us to unclutter the main documentation file, and put all the links at the bottom of the file, in a centralized place.