### PR TITLE
misc/environment: Add a warning for when sessionVariables exist but are not loaded by Hjem Rum

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ hjem.users.<username>.rum.programs.alacritty = {
 }
 ```
 
+## Environmental Variables
+
+Hjem provides attribute set "environment.sessionVariables" that allows the user to set environmental variables to be sourced. However, Hjem does not have the capability to actually source them. This can be done manually, which is what Hjem Rum tries to do.
+
+Currently, some of our modules may add environmental variables (such as our GTK module), but cannot load them without the use of another module. Currently, modules that load environmental variables include:
+
+- [fish](modules/collection/programs/fish.nix)
+- [zsh](modules/collection/programs/zsh.nix)
+- [hyprland](modules/collection/programs/hyprland.nix)
+
+If you are either using something like our GTK module, or are manually adding variables to environment.sessionVariables, but are neither loading those variables manually, or using one of the above modules, those variables will not be loaded, and may cause unintended problems. For example, GTK applications may not respect your theme, as some rely on the environmental variable to actually use the theme you declare.
+
+Please see [#17](https://github.com/snugnug/hjem-rum/issues/17) for status on providing support for shells and compositors. If your shell or compositor is on listed there, please leave a comment and it will be added. You are encouraged to open a PR to help support your shell or compositor if possible.
+
 ## Contributing
 
 Hjem Rum is always in need of contribution. Please see [CONTRIBUTING.md](./docs/CONTRIBUTING.md) for more information on how to contribute and our guidelines.

--- a/modules/collection/environment/warning.nix
+++ b/modules/collection/environment/warning.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.modules) mkIf;
+  inherit (lib.lists) optionals all;
+
+  # A list checking all modules that load variables. Enabled modules
+  # will evaluate to true, disabled will evaluate to false. Results
+  # in a list of bools, allowing us to
+  variableLoaders = [
+    config.rum.programs.zsh.enable
+    config.rum.programs.fish.enable
+    config.rum.programs.hyprland.enable
+  ];
+
+  cfg = config.rum.environment;
+in {
+  options.rum.environment.hideWarning = mkEnableOption "a warning for env vars not being implemented";
+
+  config = mkIf (!cfg.hideWarning) {
+    # If all modules are disabled, then Hjem Rum is not loading variables
+    warnings = optionals ((all (module: !module) variableLoaders) && (config.environment.sessionVariables != {})) [
+      "environment.sessionVariables exist but are not being loaded by any Hjem Rum modules. Please see the README for more information. If you would like to disable this warning, enable rum.environment.hideWarning."
+    ];
+  };
+}


### PR DESCRIPTION
Title. Basically, if users use a module that adds to sessionVariables (such as GTK) or simply add to it themselves (like for ozone), they may not know that it is not automatically loaded without the use of another module.

This has a very basic warning message so that users are aware at least. Once docs are in I would like to add a page on sessionVariables and direct users there for a warning.

There is also an option to disable the warning for users manually loading sessionVariables.