### PR TITLE
flake: add treefmt-nix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,10 @@ repos:
         files: .+\.nix$
 
       # mdformat automatically uses any plugin that is installed
-      - id: mdformat
+      - id: deno
         name: format markdown files
         language: system
-        entry: mdformat
+        entry: deno fmt --check
         files: .+\.md$
 
       - id: commitizen

--- a/README.md
+++ b/README.md
@@ -1,22 +1,42 @@
 # Hjem Rum
 
-A module collection for managing your `$HOME` with [Hjem](https://github.com/feel-co/hjem).
+A module collection for managing your `$HOME` with
+[Hjem](https://github.com/feel-co/hjem).
 
 ## A brief explanation
 
-> \[!IMPORTANT\]
-> Hjem, the tooling Hjem Rum is built off of, is still unfinished. Use at your own risk, and beware of bugs, issues, and missing features. If you do not feel like being a beta tester, wait until Hjem is more finished. It is not yet ready to fully replace Home Manager in the average user's config, but if you truly want to, an option could be to use both in conjunction. Either way, as Hjem continues to be developed, Hjem Rum will be worked on as we build modules and functionality out to support average users.
+> [!IMPORTANT]
+> Hjem, the tooling Hjem Rum is built off of, is still unfinished. Use at your
+> own risk, and beware of bugs, issues, and missing features. If you do not feel
+> like being a beta tester, wait until Hjem is more finished. It is not yet
+> ready to fully replace Home Manager in the average user's config, but if you
+> truly want to, an option could be to use both in conjunction. Either way, as
+> Hjem continues to be developed, Hjem Rum will be worked on as we build modules
+> and functionality out to support average users.
 
-Based on the Hjem tooling, Hjem Rum (literally meaning "home rooms") is a collection of modules for various programs and services to simplify the use of Hjem for managing your `$HOME` files.
+Based on the Hjem tooling, Hjem Rum (literally meaning "home rooms") is a
+collection of modules for various programs and services to simplify the use of
+Hjem for managing your `$HOME` files.
 
-Hjem was initially created as an improved implementation of the `home` functionality that Home Manager provides. Its purpose was minimal. Hjem Rum's purpose is to create a module collection based on that tooling in order to recreate the functionality that Home Manager's large collection of modules provides, allowing you to simply install and config a program.
+Hjem was initially created as an improved implementation of the `home`
+functionality that Home Manager provides. Its purpose was minimal. Hjem Rum's
+purpose is to create a module collection based on that tooling in order to
+recreate the functionality that Home Manager's large collection of modules
+provides, allowing you to simply install and config a program.
 
 ## Setup
 
-> \[!WARNING\]
-> Importing Hjem Rum as a NixOS Module is being deprecated in favor of a Hjem Module. While this should not change user-side functionality, it does mean you will need to change where you import Hjem Rum in your config, and how you do so. If you were previously using Hjem Rum with the soon-to-be deprecated NixOS Module (importing it into `imports`), please see below on how to update to the Hjem Module. For more information on why this was done, see [#30](https://github.com/snugnug/hjem-rum/pull/30).
+> [!WARNING]
+> Importing Hjem Rum as a NixOS Module is being deprecated in favor of a Hjem
+> Module. While this should not change user-side functionality, it does mean you
+> will need to change where you import Hjem Rum in your config, and how you do
+> so. If you were previously using Hjem Rum with the soon-to-be deprecated NixOS
+> Module (importing it into `imports`), please see below on how to update to the
+> Hjem Module. For more information on why this was done, see
+> [#30](https://github.com/snugnug/hjem-rum/pull/30).
 
-To start using Hjem Rum, you must first import the flake and its modules into your system(s):
+To start using Hjem Rum, you must first import the flake and its modules into
+your system(s):
 
 ```nix
 # flake.nix
@@ -55,7 +75,8 @@ outputs = {
 }
 ```
 
-Be sure to first set the necessary settings for Hjem and import the Hjem module from the input:
+Be sure to first set the necessary settings for Hjem and import the Hjem module
+from the input:
 
 ```nix
 # configuration.nix
@@ -75,7 +96,8 @@ hjem = {
 };
 ```
 
-You can then configure any of the options defined in this flake in any nix module:
+You can then configure any of the options defined in this flake in any nix
+module:
 
 ```nix
 # configuration.nix
@@ -99,12 +121,17 @@ hjem.users.<username>.rum.programs.alacritty = {
 
 ## Contributing
 
-Hjem Rum is always in need of contribution. Please see [CONTRIBUTING.md](./docs/CONTRIBUTING.md) for more information on how to contribute and our guidelines.
+Hjem Rum is always in need of contribution. Please see
+[CONTRIBUTING.md](./docs/CONTRIBUTING.md) for more information on how to
+contribute and our guidelines.
 
 ## Credits
 
-Credit goes to [@NotAShelf](https://github.com/NotAShelf) and [@éclairevoyant](https://github.com/eclairevoyant) for creating Hjem.
+Credit goes to [@NotAShelf](https://github.com/NotAShelf) and
+[@éclairevoyant](https://github.com/eclairevoyant) for creating Hjem.
 
 ## License
 
-All the code within this repository is protected under the GPLv3 license unless explicitly stated otherwise within a file. Please see [LICENSE](LICENSE) for more information.
+All the code within this repository is protected under the GPLv3 license unless
+explicitly stated otherwise within a file. Please see [LICENSE](LICENSE) for
+more information.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,23 +11,6 @@ If you are familiar with contributing to open source software, you can safely
 skip ahead to [Core Principles](#core-principles). Otherwise, read the following
 section to learn how to fork a repo and open a PR.
 
-<!-- mdformat-toc start --slug=github --maxlevel=6 --minlevel=2 -->
-
-- [Getting Started](#getting-started)
-  - [Commit format](#commit-format)
-- [Core Principles](#core-principles)
-- [Guidelines](#guidelines)
-  - [Where to put a new module](#where-to-put-a-new-module)
-  - [Aliases](#aliases)
-  - [Writing Options](#writing-options)
-  - [Conditional Config](#conditional-config)
-  - [Extending Lib](#extending-lib)
-  - [Docs](#docs)
-  - [Tests](#tests)
-- [Reviewing a PR](#reviewing-a-pr)
-
-<!-- mdformat-toc end -->
-
 ## Getting Started<a name="getting-started"></a>
 
 To begin contributing to HJR, you will first need to create a fork off of the

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,7 +44,8 @@ details, the most important thing is to make and switch to a branch from HEAD.
 
 ### Commit format<a name="commit-format"></a>
 
-> \[!INFO\] Our dev shell allows for interactive commits, through the means of
+> [!INFO]
+> Our dev shell allows for interactive commits, through the means of
 > [commitizen](https://github.com/commitizen-tools/commitizen). If this is
 > preferred, you can run `cz commit` to be prompted to build your commit.
 

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,28 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1745929750,
+        "narHash": "sha256-k5ELLpTwRP/OElcLpNaFWLNf8GRDq4/eHBmFy06gGko=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "82bf32e541b30080d94e46af13d46da0708609ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,11 @@
       {
         projectRootFile = "flake.nix";
         programs.alejandra.enable = true;
-        programs.mdformat.enable = true;
+        programs.deno.enable = true;
+
+        settings = {
+          deno.includes = ["*.md"];
+        };
       });
   in {
     hjemModules = {
@@ -53,9 +57,6 @@
         default = pkgs.mkShell {
           packages = with pkgs; [
             pre-commit
-            python312Packages.mdformat-footnote
-            python312Packages.mdformat-toc
-            python312Packages.mdformat-gfm
             python312Packages.commitizen
           ];
           inputsFrom = [


### PR DESCRIPTION
Title. This would be useful to have, as it makes `nix fmt` universally format everything nicely. It even provides its own dependencies under a devshell, that has also been added to our own. 

This is the reason why `python312Packages.mdformat` and `alejandra` were taken out of the `mkShell.packages`.