### PR TITLE
flake/hjemModule: expose modulesPath, stop mass importing by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ A module collection for managing your `$HOME` with [Hjem].
 > Hjem, the tooling Hjem Rum is built off of, is still unfinished. Use at your
 > own risk, and beware of bugs, issues, and missing features. If you do not feel
 > like being a beta tester, wait until Hjem is more finished. It is not yet
-> ready to fully replace Home Manager in the average user's config, but if you
-> truly want to, an option could be to use both in conjunction. Either way, as
-> Hjem continues to be developed, Hjem Rum will be worked on as we build modules
-> and functionality out to support average users.
+> ready to fully replace Home Manager in the average user's configuration, but
+> if you truly want to, an option could be to use both in conjunction. Either
+> way, as Hjem continues to be developed, Hjem Rum will be worked on as we build
+> modules and functionality out to support average users.
 
 Based on the Hjem tooling, Hjem Rum (literally meaning "home rooms") is a
 collection of modules for various programs and services to simplify the use of
@@ -33,7 +33,7 @@ Hjem was initially created as an improved implementation of the `home`
 functionality that Home Manager provides. Its purpose was minimal. Hjem Rum's
 purpose is to create a module collection based on that tooling in order to
 recreate the functionality that Home Manager's large collection of modules
-provides, allowing you to simply install and config a program.
+provides, allowing you to simply install and configure a program.
 
 ## Setup
 
@@ -101,8 +101,8 @@ hjem = {
 };
 ```
 
-You can then configure any of the options defined in this flake in any nix
-module:
+You may then configure any of the options defined in imported modules in your
+own configuration:
 
 ```nix
 # configuration.nix

--- a/README.md
+++ b/README.md
@@ -127,6 +127,51 @@ hjem.users.<username>.rum.programs.alacritty = {
 > [!TIP]
 > Consult the [documentation] for an overview of all available options.
 
+### Optional: Manual Module Importing
+
+> [!WARNING]
+> Manual module importing is an advanced user feature and is not recommended for
+> the average user. While it is supported and tested for, you may encounter more
+> problems with it, and we advise users to become more familiar with the NixOS
+> module system and Hjem Rum in particular before attempting to leave behind the
+> automatic importing of all modules. Please skip ahead to [Environmental
+> Variables] if you are not interested in this. While the default hjemModule
+> imports all modules in the collection recursively, we have implemented
+> functionality to support users who would prefer to only import modules that
+> they plan to use. If you would like to do so, rather than importing the
+> default hjemModule we provide, you will have to use the special `bare` module:
+
+```nix
+hjem.extraModules = [
+    inputs.hjem-rum.hjemModules.bare # The alternative module
+    # inputs.hjem-rum.hjemModules.default
+];
+```
+
+This alternative module does not import any of our modules, which means that you
+will not be able to do anything with Hjem Rum without manually importing our
+modules yourself. To this end, we offer a `modulesPath` output for you to import
+modules from.
+
+```nix
+hjem.extraModules = [
+    # Notice the similarity to the programs.alacritty namespace
+    "${inputs.hjem-rum.modulesPath}/programs/alacritty.nix" # Importing the alacritty module
+];
+```
+
+We strongly recommend importing `environment/warning.nix`
+when setting up Hjem Rum, as it offers useful checking and a warning if your
+session variables are not actually being used.
+
+```nix
+hjem.extraModules = [
+    "${modulesPath}/environment/warning.nix"
+];
+```
+
+See more information below.
+
 ## Environmental Variables
 
 Hjem provides attribute set "environment.sessionVariables" that allows the user

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,6 +4,7 @@
 [nix.dev provides a useful guide]: https://nix.dev/tutorials/nixos/integration-testing-using-virtual-machines.html
 [NixOS Manual]: https://nixos.org/manual/nixos/stable/index.html#sec-calling-nixos-tests
 [internal NixOS lib]: https://github.com/NixOS/nixpkgs/tree/master/nixos/lib/testing
+[README.md]: ../README.md#optional-importing
 
 Hjem Rum's testing system is designed with simplicity in mind, so we shy away
 from other testing frameworks and stick with `runTest`, from the
@@ -57,9 +58,8 @@ Our test system has some pre-defined things aiming at avoid boilerplate code:
 - A user named "bob" is already created, with no groups, `isNormalUser` set to
   true and no password.
 - Both Hjem and Hjem Rum are already imported by default.
-
-`self`, `lib` and `pkgs` are also passed to every test module, so you're free to
-use them as you will.
+- `self`, `lib` and `pkgs` are passed to every test module, so you're free to
+  use them as you will.
 
 The [ncmpcpp test module] was written to serve as an example for future tests,
 and provides comments for each step of the `testScript`. Care should be taken to
@@ -68,6 +68,12 @@ and avoid other possible footguns. The approach this module uses to test its
 configuration is to have a file for each configuration alongside it, which then
 gets passed to the test VM and gets evaluated with diff. You can use other
 approaches if it's more convenient, that's just a suggestion.
+
+You will need to import the module itself as well as any dependent modules. This
+is not done automatically as to check for dependency changes and to ensure our
+table of module dependencies remain up to date. If your test requires the
+importing of modules other than the program being tested, ensure that is noted
+in [README.md].
 
 You can also debug your tests through a Python REPL by running:
 

--- a/flake.nix
+++ b/flake.nix
@@ -46,11 +46,12 @@
       });
   in {
     hjemModules = {
-      hjem-rum = import ./modules/hjem.nix {
+      complete = import ./modules/hjem.nix {
         inherit (nixpkgs) lib;
         inherit rumLib;
       };
-      default = self.hjemModules.hjem-rum;
+      bare = {_module.args = {inherit rumLib;};};
+      default = self.hjemModules.complete;
     };
     packages = forAllSystems (pkgs: {
       docs = pkgs.callPackage ./docs/package.nix {
@@ -58,6 +59,9 @@
         inherit rumLib;
       };
     });
+
+    modulesPath = ./modules/collection;
+
     lib = rumLib;
 
     devShells = forAllSystems (

--- a/modules/collection/environment/warning.nix
+++ b/modules/collection/environment/warning.nix
@@ -11,10 +11,10 @@
   # will evaluate to true, disabled will evaluate to false. Results
   # in a list of bools, allowing us to
   variableLoaders = [
-    config.rum.programs.zsh.enable
-    config.rum.programs.fish.enable
-    config.rum.programs.nushell.enable
-    config.rum.desktops.hyprland.enable
+    (config.rum.programs.zsh.enable or false)
+    (config.rum.programs.fish.enable or false)
+    (config.rum.programs.nushell.enable or false)
+    (config.rum.desktops.hyprland.enable or false)
   ];
 
   cfg = config.rum.environment;

--- a/modules/collection/programs/zsh.nix
+++ b/modules/collection/programs/zsh.nix
@@ -40,13 +40,6 @@
 
   cfg = config.rum.programs.zsh;
 in {
-  imports = [
-    (
-      mkRenamedOptionModule
-      ["rum" "programs" "zsh" "integrations" "starship" "enable"]
-      ["rum" "programs" "starship" "integrations" "zsh" "enable"]
-    )
-  ];
   options.rum.programs.zsh = {
     enable = mkEnableOption "zsh";
     package = mkPackageOption pkgs "zsh" {nullable = true;};

--- a/modules/hjem.nix
+++ b/modules/hjem.nix
@@ -2,13 +2,11 @@
   lib,
   rumLib,
 }: {
-  # Import the Hjem Rum module collection as an extraModule available under `hjem.users.<username>`
-  # This allows the definition of rum modules under `hjem.users.<username>.rum`
-
-  # Import the collection modules recursively so that all files
-  # are imported. This then gets imported into the user's
-  # 'hjem.extraModules' to make them available under 'hjem.users.<username>'
+  /*
+  Import all modules contained within the collection directory recursively so that all files are passed into`imports` as a list. The user then imports this into `hjem.extraModules` to make them available under `hjem.users.<username>`.
+  */
   imports = lib.filesystem.listFilesRecursive ./collection;
 
+  # We declare special args needed within the Hjem Modules.
   _module.args.rumLib = rumLib;
 }

--- a/modules/tests/default.nix
+++ b/modules/tests/default.nix
@@ -28,7 +28,7 @@ Usage: (import ./location-of-lib.nix) {test-script-here}
       defaults = {
         documentation.enable = lib.mkDefault false;
         imports = [self.inputs.hjem.nixosModules.default];
-        hjem.extraModules = [self.hjemModules.default];
+        hjem.extraModules = [self.hjemModules.bare]; # We import the bare module to check for module dependencies
         users.groups.bob = {};
         users.users.bob = {
           isNormalUser = true;

--- a/modules/tests/programs/beets/bad-settings.nix
+++ b/modules/tests/programs/beets/bad-settings.nix
@@ -1,10 +1,13 @@
 {
   name = "programs-beets-no-file-created";
-  nodes.machine = {
-    hjem.users.bob.rum = {
-      programs.beets = {
-        enable = true;
-        settings = {};
+  nodes.machine = {self, ...}: {
+    hjem = {
+      extraModules = ["${self.modulesPath}/programs/beets.nix"];
+      users.bob.rum = {
+        programs.beets = {
+          enable = true;
+          settings = {};
+        };
       };
     };
   };

--- a/modules/tests/programs/beets/beets.nix
+++ b/modules/tests/programs/beets/beets.nix
@@ -7,12 +7,15 @@
   settingsFile = yaml.generate "settings.yaml" settings;
 in {
   name = "programs-beets";
-  nodes.machine = {
-    hjem.users.bob.rum = {
-      programs.beets = {
-        enable = true;
-        package = pkgs.beets.override {pluginOverrides.duplicates.enable = true;};
-        inherit settings;
+  nodes.machine = {self, ...}: {
+    hjem = {
+      extraModules = ["${self.modulesPath}/programs/beets.nix"];
+      users.bob.rum = {
+        programs.beets = {
+          enable = true;
+          package = pkgs.beets.override {pluginOverrides.duplicates.enable = true;};
+          inherit settings;
+        };
       };
     };
   };

--- a/modules/tests/programs/direnv/direnv.nix
+++ b/modules/tests/programs/direnv/direnv.nix
@@ -1,6 +1,12 @@
 {
   name = "programs-direnv";
-  nodes.machine = {
+  nodes.machine = {self, ...}: {
+    # TODO: Separate fish and zsh integration tests into their own tests
+    hjem.extraModules = [
+      "${self.modulesPath}/programs/direnv.nix"
+      "${self.modulesPath}/programs/fish.nix"
+      "${self.modulesPath}/programs/zsh.nix"
+    ];
     hjem.users.bob.rum = {
       programs.direnv = {
         enable = true;

--- a/modules/tests/programs/fish.nix
+++ b/modules/tests/programs/fish.nix
@@ -1,21 +1,24 @@
 {pkgs, ...}: {
   name = "programs-fish";
-  nodes.machine = {
-    hjem.users.bob = {
-      environment.sessionVariables = {
-        RUM_TEST = "HEY";
-      };
-
-      rum.programs.fish = {
-        enable = true;
-        plugins = {inherit (pkgs.fishPlugins) z;};
-        earlyConfigFiles = {
-          hello = ''
-            echo Welcome
-          '';
+  nodes.machine = {self, ...}: {
+    hjem = {
+      extraModules = ["${self.modulesPath}/programs/fish.nix"];
+      users.bob = {
+        environment.sessionVariables = {
+          RUM_TEST = "HEY";
         };
-        abbrs = {
-          foo = "bar";
+
+        rum.programs.fish = {
+          enable = true;
+          plugins = {inherit (pkgs.fishPlugins) z;};
+          earlyConfigFiles = {
+            hello = ''
+              echo Welcome
+            '';
+          };
+          abbrs = {
+            foo = "bar";
+          };
         };
         aliases = {
           ping = "ping -c 5";

--- a/modules/tests/programs/fish.nix
+++ b/modules/tests/programs/fish.nix
@@ -19,9 +19,9 @@
           abbrs = {
             foo = "bar";
           };
-        };
-        aliases = {
-          ping = "ping -c 5";
+          aliases = {
+            ping = "ping -c 5";
+          };
         };
       };
     };

--- a/modules/tests/programs/flameshot/flameshot.nix
+++ b/modules/tests/programs/flameshot/flameshot.nix
@@ -13,7 +13,8 @@ let
   };
 in {
   name = "programs-flameshot";
-  nodes.machine = {
+  nodes.machine = {self, ...}: {
+    hjem.extraModules = ["${self.modulesPath}/programs/flameshot.nix"];
     hjem.users.bob.rum = {
       programs.flameshot = {
         enable = true;

--- a/modules/tests/programs/foot.nix
+++ b/modules/tests/programs/foot.nix
@@ -13,11 +13,14 @@ let
   };
 in {
   name = "programs-foot";
-  nodes.machine = {
-    hjem.users.bob.rum = {
-      programs.foot = {
-        enable = true;
-        inherit settings;
+  nodes.machine = {self, ...}: {
+    hjem = {
+      extraModules = ["${self.modulesPath}/programs/foot.nix"];
+      users.bob.rum = {
+        programs.foot = {
+          enable = true;
+          inherit settings;
+        };
       };
     };
   };

--- a/modules/tests/programs/fuzzel.nix
+++ b/modules/tests/programs/fuzzel.nix
@@ -1,6 +1,7 @@
 {
   name = "programs-fuzzel";
-  nodes.machine = {
+  nodes.machine = {self, ...}: {
+    hjem.extraModules = ["${self.modulesPath}/programs/fuzzel.nix"];
     hjem.users.bob.rum = {
       programs.fuzzel = {
         enable = true;

--- a/modules/tests/programs/fzf.nix
+++ b/modules/tests/programs/fzf.nix
@@ -1,6 +1,12 @@
 {
   name = "programs-fzf";
-  nodes.machine = {
+  nodes.machine = {self, ...}: {
+    # TODO: Separate fish and zsh integration tests into their own tests
+    hjem.extraModules = [
+      "${self.modulesPath}/programs/fzf.nix"
+      "${self.modulesPath}/programs/fish.nix"
+      "${self.modulesPath}/programs/zsh.nix"
+    ];
     hjem.users.bob.rum = {
       programs.fzf = {
         enable = true;

--- a/modules/tests/programs/ghostty.nix
+++ b/modules/tests/programs/ghostty.nix
@@ -37,7 +37,8 @@ let
   };
 in {
   name = "programs-ghostty";
-  nodes.machine = {
+  nodes.machine = {self, ...}: {
+    hjem.extraModules = ["${self.modulesPath}/programs/ghostty.nix"];
     hjem.users.bob.rum = {
       programs.ghostty = {
         enable = true;

--- a/modules/tests/programs/git/git.nix
+++ b/modules/tests/programs/git/git.nix
@@ -1,6 +1,7 @@
 {
   name = "programs-git";
-  nodes.machine = {
+  nodes.machine = {self, ...}: {
+    hjem.extraModules = ["${self.modulesPath}/programs/git.nix"];
     hjem.users.bob.rum = {
       programs.git = {
         enable = true;

--- a/modules/tests/programs/kitty/kitty.nix
+++ b/modules/tests/programs/kitty/kitty.nix
@@ -1,6 +1,12 @@
 {pkgs, ...}: {
   name = "programs-kitty";
-  nodes.machine = {
+  nodes.machine = {self, ...}: {
+    # TODO: Separate fish and zsh integration tests into their own tests
+    hjem.extraModules = [
+      "${self.modulesPath}/programs/kitty.nix"
+      "${self.modulesPath}/programs/fish.nix"
+      "${self.modulesPath}/programs/zsh.nix"
+    ];
     hjem.users.bob.rum = {
       programs.kitty = {
         enable = true;

--- a/modules/tests/programs/ncmpcpp/ncmpcpp.nix
+++ b/modules/tests/programs/ncmpcpp/ncmpcpp.nix
@@ -1,42 +1,45 @@
 {
   name = "programs-ncmpcpp";
-  nodes.machine = {
-    hjem.users.bob.rum = {
-      programs.ncmpcpp = {
-        enable = true;
+  nodes.machine = {self, ...}: {
+    hjem = {
+      extraModules = ["${self.modulesPath}/programs/ncmpcpp.nix"];
+      users.bob.rum = {
+        programs.ncmpcpp = {
+          enable = true;
 
-        # This aims to test the ncmpcpp generator type conversion
-        # Options were chose at random
-        settings = {
-          mpd_host = "localhost";
-          mpd_port = 6600;
-          mpd_crossfade_time = 32;
-          incremental_seeking = true;
-        };
+          # This aims to test the ncmpcpp generator type conversion
+          # Options were chose at random
+          settings = {
+            mpd_host = "localhost";
+            mpd_port = 6600;
+            mpd_crossfade_time = 32;
+            incremental_seeking = true;
+          };
 
-        bindings = {
-          keys = [
-            {
-              binding = "ctrl-q";
-              actions = ["stop" "quit"];
-            }
-            {
-              binding = "q";
-              actions = ["quit"];
-              deferred = true;
-            }
-          ];
-          commands = [
-            {
-              binding = "!sq";
-              actions = ["stop" "quit"];
-            }
-            {
-              binding = "!q";
-              actions = ["quit"];
-              deferred = true;
-            }
-          ];
+          bindings = {
+            keys = [
+              {
+                binding = "ctrl-q";
+                actions = ["stop" "quit"];
+              }
+              {
+                binding = "q";
+                actions = ["quit"];
+                deferred = true;
+              }
+            ];
+            commands = [
+              {
+                binding = "!sq";
+                actions = ["stop" "quit"];
+              }
+              {
+                binding = "!q";
+                actions = ["quit"];
+                deferred = true;
+              }
+            ];
+          };
         };
       };
     };

--- a/modules/tests/programs/nushell.nix
+++ b/modules/tests/programs/nushell.nix
@@ -10,7 +10,8 @@
   '';
 in {
   name = "programs-nushell";
-  nodes.machine = {
+  nodes.machine = {self, ...}: {
+    hjem.extraModules = ["${self.modulesPath}/programs/nushell.nix"];
     hjem.users.bob = {
       environment.sessionVariables = {
         RUM_TEST = "HEY";

--- a/modules/tests/programs/tealdeer/tealdeer.nix
+++ b/modules/tests/programs/tealdeer/tealdeer.nix
@@ -15,7 +15,8 @@ let
   };
 in {
   name = "programs-tealdeer";
-  nodes.machine = {
+  nodes.machine = {self, ...}: {
+    hjem.extraModules = ["${self.modulesPath}/programs/tealdeer.nix"];
     hjem.users.bob.rum = {
       programs.tealdeer = {
         enable = true;

--- a/modules/tests/programs/zoxide.nix
+++ b/modules/tests/programs/zoxide.nix
@@ -1,6 +1,13 @@
 {
   name = "programs-zoxide";
-  nodes.machine = {
+  nodes.machine = {self, ...}: {
+    # TODO: Separate fish, nushell, and zsh integration tests into their own tests
+    hjem.extraModules = [
+      "${self.modulesPath}/programs/zoxide.nix"
+      "${self.modulesPath}/programs/fish.nix"
+      "${self.modulesPath}/programs/nushell.nix"
+      "${self.modulesPath}/programs/zsh.nix"
+    ];
     hjem.users.bob.rum = {
       programs.zoxide = {
         enable = true;


### PR DESCRIPTION
Some users may wish to use HJR but be discouraged by lengthening eval times. For that reason, we have added an output that links to the module collection, extensively modified README.md, and stopped importing the entire module collection by default.

Users who still want to import the entire module collection automatically can use `lib.filesystem.listFilesRecursive`, as explained in the readme.

While I am marking this as ready for review since it does in fact work in my config, I am not entirely set on this approach and would love some feedback.

Closes #65. 