### PR TITLE
programs/flameshot: init module, add tests

### DIFF
--- a/modules/collection/programs/flameshot.nix
+++ b/modules/collection/programs/flameshot.nix
@@ -1,0 +1,45 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
+
+  ini = pkgs.formats.ini {};
+
+  cfg = config.rum.programs.flameshot;
+in {
+  options.rum.programs.flameshot = {
+    enable = mkEnableOption "flameshot";
+
+    package = mkPackageOption pkgs "flameshot" {};
+
+    settings = mkOption {
+      type = ini.type;
+      default = {};
+      example = {
+        General = {
+          disabledTrayIcon = true;
+          saveLastRegion = true;
+          showDesktopNotification = false;
+          showStartupLaunchMessage = false;
+        };
+      };
+      description = ''
+        Configuration written to {file}`$HOME/.config/flameshot/flameshot.ini`.
+        Please reference [flameshot's example config] for config options.
+
+        [flameshot's example config]: https://github.com/flameshot-org/flameshot/blob/master/flameshot.example.ini
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    packages = [cfg.package];
+    files.".config/flameshot/flameshot.ini".source = mkIf (cfg.settings != {}) (
+      ini.generate "flameshot.ini" cfg.settings
+    );
+  };
+}

--- a/modules/tests/programs/flameshot/expected_config
+++ b/modules/tests/programs/flameshot/expected_config
@@ -1,0 +1,9 @@
+[General]
+disabledTrayIcon=true
+saveLastRegion=true
+showDesktopNotification=false
+showStartupLaunchMessage=false
+
+[Shortcuts]
+TYPE_ARROW=A
+TYPE_CIRCLE=C

--- a/modules/tests/programs/flameshot/flameshot.nix
+++ b/modules/tests/programs/flameshot/flameshot.nix
@@ -1,0 +1,44 @@
+let
+  settings = {
+    General = {
+      disabledTrayIcon = true;
+      saveLastRegion = true;
+      showDesktopNotification = false;
+      showStartupLaunchMessage = false;
+    };
+    Shortcuts = {
+      TYPE_ARROW = "A";
+      TYPE_CIRCLE = "C";
+    };
+  };
+in {
+  name = "programs-flameshot";
+  nodes.machine = {
+    hjem.users.bob.rum = {
+      programs.flameshot = {
+        enable = true;
+        inherit settings;
+      };
+    };
+  };
+
+  testScript =
+    #python
+    ''
+      # Waiting for our user to load.
+      machine.succeed("loginctl enable-linger bob")
+      machine.wait_for_unit("default.target")
+
+      confPath = "/home/bob/.config/flameshot/flameshot.ini"
+
+      # Checks if the flameshot config file exists in the expected place.
+      machine.succeed("[ -r %s ]" % confPath)
+
+      # Assert that the generated config is applied correctly.
+      machine.copy_from_host("${./expected_config}", "/home/bob/expected_config")
+      machine.succeed("diff -u -Z -b -B %s /home/bob/expected_config" % confPath)
+
+      # Letting flameshot check the validity of the config file
+      machine.succeed("su bob -c 'flameshot config --check'");
+    '';
+}


### PR DESCRIPTION
The HM variant adds a systemd service that runs the main binary without any flags. I tested the hjem module I wrote without it, and it seems to work just fine? IIRC it used to not work if the systemd service isn't there; but hey, I ain't complaining.