### PR TITLE
programs/fish: add aliases option

### DIFF
--- a/modules/collection/programs/fish.nix
+++ b/modules/collection/programs/fish.nix
@@ -106,10 +106,7 @@ in {
         [fish documentation]: https://fishshell.com/docs/current/language.html#configuration-files
       '';
       example = {
-        my-aliases = ''
-          alias la "ls -la"
-          alias ll "ls -l"
-        '';
+        set-path = "fish_add_path ~/.local/bin";
       };
     };
 
@@ -118,6 +115,14 @@ in {
       type = attrsOf str;
       description = ''
         A set of fish abbreviations, they will be set up with the `abbr --add` fish builtin.
+      '';
+    };
+
+    aliases = mkOption {
+      default = {};
+      type = attrsOf str;
+      description = ''
+        A set of fish aliases, they will be set up with the `alias` fish builtin.
       '';
     };
 
@@ -205,6 +210,9 @@ in {
         '';
         ".config/fish/conf.d/rum-abbreviations.fish".text = mkIf (cfg.abbrs != {}) ''
           ${concatMapAttrsStringSep "\n" (name: value: "abbr --add -- ${name} ${escapeShellArg (toString value)}") cfg.abbrs}
+        '';
+        ".config/fish/conf.d/rum-aliases.fish".text = mkIf (cfg.aliases != {}) ''
+          ${concatMapAttrsStringSep "\n" (name: value: "alias -- ${name} ${escapeShellArg (toString value)}") cfg.aliases}
         '';
       }
       // (mapAttrs' (name: val: nameValuePair ".config/fish/functions/${name}.fish" {source = toFishFunc val name;}) cfg.functions)

--- a/modules/tests/programs/fish.nix
+++ b/modules/tests/programs/fish.nix
@@ -17,6 +17,9 @@
         abbrs = {
           foo = "bar";
         };
+        aliases = {
+          ping = "ping -c 5";
+        };
       };
     };
   };
@@ -37,6 +40,9 @@
       with subtest("Validate abbreviations"):
           machine.succeed("su bob -c 'fish -c \"abbr --query foo\" '")
           machine.fail("su bob -c 'fish -c \"abbr --query missing\" '")
+
+      with subtest("Validate aliases"):
+          machine.succeed("su bob -c 'fish -c \"alias | grep ping\" '")
 
       with subtest("Loading of environment variables"):
           machine.succeed("su bob -c \"fish -c 'set -q RUM_TEST'\"")


### PR DESCRIPTION
This adds an option to make aliases in fish. This can be useful as people often use aliases in shells and, in the future, it would be easier to integrate shell aliases or do something like `programs.fish.aliases = config.programs.othershell.aliases` and vice-versa.