### PR TITLE
programs/fish: fix the suffix of fish functions, again

### DIFF
--- a/modules/collection/programs/fish.nix
+++ b/modules/collection/programs/fish.nix
@@ -198,7 +198,7 @@ in {
           ${concatMapAttrsStringSep "\n" (name: value: "alias -- ${name} ${escapeShellArg (toString value)}") cfg.aliases}
         '';
       }
-      // (mapAttrs' (name: val: nameValuePair ".config/fish/functions/${name}" {source = toFishFunc val name;}) cfg.functions)
+      // (mapAttrs' (name: val: nameValuePair ".config/fish/functions/${name}.fish" {source = toFishFunc val name;}) cfg.functions)
       // (mapAttrs' (name: val: nameValuePair ".config/fish/conf.d/${name}.fish" {source = writeFish "${name}.fish" val;}) cfg.earlyConfigFiles);
   };
 }


### PR DESCRIPTION
Sorry again! I wasn't home yesterday so the commits were made from a bus (hence why I didn't get this too). Now it should be fine, tested on my machine.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
