### PR TITLE
programs/direnv: add nushell integration

### DIFF
--- a/modules/tests/programs/direnv/direnv.nix
+++ b/modules/tests/programs/direnv/direnv.nix
@@ -20,9 +20,11 @@
         '';
         integrations.fish.enable = true;
         integrations.nix-direnv.enable = true;
+        integrations.nushell.enable = true;
         integrations.zsh.enable = true;
       };
       programs.fish.enable = true;
+      programs.nushell.enable = true;
       programs.zsh.enable = true;
     };
   };
@@ -50,6 +52,9 @@
       # Assert that the fish integration snippet is in place
       pattern = r'^/nix/store/[^/]+/bin/direnv hook fish | source$'
       machine.succeed(f"grep -E '{pattern}' %s" % "/home/bob/.config/fish/config.fish")
+
+      # Assert that the nushell integration snippet is in place
+      machine.succeed("grep \"direnv\" %s" % "/home/bob/.config/nushell/config.nu")
 
       # Assert that the zsh integration snippet is in place
       pattern = r'^eval "\$\(/nix/store/[^/]+/bin/direnv hook zsh\)"$'


### PR DESCRIPTION
Add nushell integration to direnv. I wanted to add it to fzf too, but it turns out it doesn't exist.

### Meta

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open