### PR TITLE
Migrate to xdg

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [programs/nushell]: modules/collection/programs/nushell.nix
 [desktops/hyprland]: modules/collection/desktops/hyprland.nix
 [#17]: https://github.com/snugnug/hjem-rum/issues/17
+[#120]: https://github.com/snugnug/hjem-rum/pull/120
 [@eclairevoyant]: https://github.com/eclairevoyant
 [@NotAShelf]: https://github.com/NotAShelf
 [documentation]: snugnug.github.io/hjem-rum/
@@ -36,6 +37,11 @@ recreate the functionality that Home Manager's large collection of modules
 provides, allowing you to simply install and config a program.
 
 ## Setup
+
+> [!IMPORTANT]
+> [#120] introduces breaking changes, as we now use `xdg.config.files` in our
+> modules. If you are getting errors related to the option not existing, please
+> update your flake's Hjem input.
 
 To start using Hjem Rum, you must first import the flake and its modules into
 your system(s):

--- a/flake.lock
+++ b/flake.lock
@@ -37,14 +37,15 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "smfh": "smfh"
       },
       "locked": {
-        "lastModified": 1746355589,
-        "narHash": "sha256-LguszqsDBTtdBxblQTtN7vOAYmfoe43aHkB8aK1dChE=",
+        "lastModified": 1754244549,
+        "narHash": "sha256-ByZ81/QttgSS1mQYttnaoMw2WnqMvQ6HCxBPOioKrOA=",
         "owner": "feel-co",
         "repo": "hjem",
-        "rev": "77b37eeb583d43e1c723119a69c906235174ce57",
+        "rev": "ee5c671eeba5cddd94f2c7de3c36f019fae5854e",
         "type": "github"
       },
       "original": {
@@ -112,6 +113,66 @@
         "ndg": "ndg",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "hjem",
+          "smfh",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1747622321,
+        "narHash": "sha256-W0dYIWgsUu6rvOJRtKLhKskkv0VhQhJYGNIq+gGUc8g=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "bd030fd9983f7fddf87be1c64aa3064c8afa24c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "smfh": {
+      "inputs": {
+        "nixpkgs": [
+          "hjem",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1749906619,
+        "narHash": "sha256-/9Ww10kYopxfCNNnNDwENTubs7Wzqlw+O6PJAHNOYQw=",
+        "owner": "feel-co",
+        "repo": "smfh",
+        "rev": "39f5c06153f63100376bc607b1465850b6df77fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "feel-co",
+        "repo": "smfh",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "treefmt-nix": {

--- a/modules/collection/desktops/hyprland.nix
+++ b/modules/collection/desktops/hyprland.nix
@@ -69,7 +69,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    files = let
+    xdg.config.files = let
       check = {
         plugins = cfg.plugins != [];
         settings = cfg.settings != {};
@@ -80,7 +80,7 @@ in {
         extraConfig = cfg.extraConfig != "";
       };
     in {
-      ".config/hypr/hyprland.conf".text = mkIf (check.plugins || check.settings || check.variables.noUWSM || check.extraConfig) (
+      "hypr/hyprland.conf".text = mkIf (check.plugins || check.settings || check.variables.noUWSM || check.extraConfig) (
         optionalString check.plugins (pluginsToHyprconf cfg.plugins cfg.importantPrefixes)
         + optionalString check.settings (toHyprconf {
           attrs = cfg.settings;
@@ -103,11 +103,11 @@ in {
       uwsm environment variables are advised to be separated
       (see https://wiki.hyprland.org/Configuring/Environment-variables/)
       */
-      ".config/uwsm/env".text =
+      "uwsm/env".text =
         mkIf check.variables.withUWSM
         (toEnvExport config.environment.sessionVariables);
 
-      ".config/uwsm/env-hyprland".text = let
+      "uwsm/env-hyprland".text = let
         /*
         this is needed as we're using a predicate so we don't create an empty file
         (improvements are welcome)

--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -63,7 +63,7 @@ in {
         type = lines;
         default = "";
         description = ''
-          CSS to be written to {file}`$HOME/.config/gtk-3.0/gtk.css`.
+          CSS to be written to {file}`$XDG_CONFIG_HOME/gtk-3.0/gtk.css`.
           You can either use this as lines or you can reference
           a CSS file from your theme's package (or both).
         '';
@@ -72,7 +72,7 @@ in {
         type = lines;
         default = "";
         description = ''
-          CSS to be written to {file}`$HOME/.config/gtk-4.0/gtk.css`.
+          CSS to be written to {file}`$XDG_CONFIG_HOME/gtk-4.0/gtk.css`.
           You can either use this as lines or you can reference
           a CSS file from your theme's package (or both).
         '';
@@ -105,20 +105,22 @@ in {
 
     inherit (cfg) packages;
 
-    files = (
+    files = optionalAttrs (cfg.settings != {}) {
+      ".gtkrc-2.0".text = toGtk2Text {inherit (cfg) settings;};
+    };
+    xdg.config.files = (
       optionalAttrs (cfg.settings != {}) {
-        ".gtkrc-2.0".text = toGtk2Text {inherit (cfg) settings;};
-        ".config/gtk-3.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
-        ".config/gtk-4.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
+        "gtk-3.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
+        "gtk-4.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
       }
       // optionalAttrs (cfg.css.gtk3 != "") {
-        ".config/gtk-3.0/gtk.css".text = cfg.css.gtk3;
+        "gtk-3.0/gtk.css".text = cfg.css.gtk3;
       }
       // optionalAttrs (cfg.css.gtk4 != "") {
-        ".config/gtk-4.0/gtk.css".text = cfg.css.gtk4;
+        "gtk-4.0/gtk.css".text = cfg.css.gtk4;
       }
       // optionalAttrs (cfg.bookmarks != []) {
-        ".config/gtk-3.0/bookmarks".text = concatStringsSep "\n" cfg.bookmarks;
+        "gtk-3.0/bookmarks".text = concatStringsSep "\n" cfg.bookmarks;
       }
     );
 

--- a/modules/collection/programs/alacritty.nix
+++ b/modules/collection/programs/alacritty.nix
@@ -34,7 +34,7 @@ in {
       };
       description = ''
         The configuration converted into TOML and written to
-        {file}`$HOME/.config/alacritty/alacritty.toml`.
+        {file}`$XDG_CONFIG_HOME/alacritty/alacritty.toml`.
         Please reference [Alacritty's documentation]
         for config options.
 
@@ -45,7 +45,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/alacritty/alacritty.toml".source = mkIf (cfg.settings != {}) (
+    xdg.config.files."alacritty/alacritty.toml".source = mkIf (cfg.settings != {}) (
       toml.generate "alacritty.toml" cfg.settings
     );
   };

--- a/modules/collection/programs/beets.nix
+++ b/modules/collection/programs/beets.nix
@@ -37,7 +37,7 @@ in {
       inherit (yaml) type;
       default = {};
       description = ''
-        Beets configuration that is written to {file}`$HOME/.config/beets/config.yaml`.
+        Beets configuration that is written to {file}`$XDG_CONFIG_HOME/beets/config.yaml`.
         Refer to the beets [documentation] for available options.
 
         If you would like to use plugins, please consult the description of
@@ -69,7 +69,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/beets/config.yaml".source = mkIf (cfg.settings != {}) (
+    xdg.config.files."beets/config.yaml".source = mkIf (cfg.settings != {}) (
       yaml.generate "config.yaml" cfg.settings
     );
   };

--- a/modules/collection/programs/bottom.nix
+++ b/modules/collection/programs/bottom.nix
@@ -28,7 +28,7 @@ in {
       };
       description = ''
         The configuration converted into TOML and written to
-        {file}`$HOME/.config/bottom/bottom.toml`.
+        {file}`$XDG_CONFIG_HOME/bottom/bottom.toml`.
 
         Please reference [bottom's config file documentation]
         for config options.
@@ -40,7 +40,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/bottom/bottom.toml".source = mkIf (cfg.settings != {}) (
+    xdg.config.files."bottom/bottom.toml".source = mkIf (cfg.settings != {}) (
       toml.generate "bottom.toml" cfg.settings
     );
   };

--- a/modules/collection/programs/direnv.nix
+++ b/modules/collection/programs/direnv.nix
@@ -26,7 +26,7 @@ in {
         whitelist.prefix = ["~/src"];
       };
       description = ''
-        Configuration written to {file}`$HOME/.config/direnv/direnv.toml`.
+        Configuration written to {file}`$XDG_CONFIG_HOME/direnv/direnv.toml`.
         Please reference [direnv's documentation] for config options.
 
         [direnv's documentation]: https://direnv.net/man/direnv.toml.1.html
@@ -71,12 +71,12 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files = {
-      ".config/direnv/direnv.toml".source = mkIf (cfg.settings != {}) (
+    xdg.config.files = {
+      "direnv/direnv.toml".source = mkIf (cfg.settings != {}) (
         toml.generate "direnv-config.toml" cfg.settings
       );
-      ".config/direnv/direnvrc".text = mkIf (cfg.direnvrc != "") cfg.direnvrc;
-      ".config/direnv/lib/nix-direnv.sh".source = mkIf cfg.integrations.nix-direnv.enable "${cfg.integrations.nix-direnv.package}/share/nix-direnv/direnvrc";
+      "direnv/direnvrc".text = mkIf (cfg.direnvrc != "") cfg.direnvrc;
+      "direnv/lib/nix-direnv.sh".source = mkIf cfg.integrations.nix-direnv.enable "${cfg.integrations.nix-direnv.package}/share/nix-direnv/direnvrc";
     };
 
     rum.programs.fish.config = mkIf cfg.integrations.fish.enable (

--- a/modules/collection/programs/fish.nix
+++ b/modules/collection/programs/fish.nix
@@ -85,9 +85,9 @@ in {
       type = attrsOf lines;
       description = ''
         Extra configuration files, they will all be written verbatim
-        to `.config/fish/conf.d/<name>.fish`.
+        to {file}`$XDG_CONFIG_HOME/fish/conf.d/<name>.fish`.
 
-        Those files are run before `.config/fish/config.fish` as per the [fish documentation].
+        Those files are run before {file}`$XDG_CONFIG_HOME/fish/config.fish` as per the [fish documentation].
 
         [fish documentation]: https://fishshell.com/docs/current/language.html#configuration-files
       '';
@@ -185,20 +185,20 @@ in {
       '')
     (filterAttrs (n: v: !(isVendored v)) cfg.plugins);
 
-    files =
+    xdg.config.files =
       {
-        ".config/fish/config.fish".source = mkIf (cfg.config != "") (writeFish "config.fish" cfg.config);
-        ".config/fish/conf.d/rum-environment-variables.fish".text = mkIf (env != {}) ''
+        "fish/config.fish".source = mkIf (cfg.config != "") (writeFish "config.fish" cfg.config);
+        "fish/conf.d/rum-environment-variables.fish".text = mkIf (env != {}) ''
           ${concatMapAttrsStringSep "\n" (name: value: "set --global --export ${name} ${toString value}") env}
         '';
-        ".config/fish/conf.d/rum-abbreviations.fish".text = mkIf (cfg.abbrs != {}) ''
+        "fish/conf.d/rum-abbreviations.fish".text = mkIf (cfg.abbrs != {}) ''
           ${concatMapAttrsStringSep "\n" (name: value: "abbr --add -- ${name} ${escapeShellArg (toString value)}") cfg.abbrs}
         '';
-        ".config/fish/conf.d/rum-aliases.fish".text = mkIf (cfg.aliases != {}) ''
+        "fish/conf.d/rum-aliases.fish".text = mkIf (cfg.aliases != {}) ''
           ${concatMapAttrsStringSep "\n" (name: value: "alias -- ${name} ${escapeShellArg (toString value)}") cfg.aliases}
         '';
       }
-      // (mapAttrs' (name: val: nameValuePair ".config/fish/functions/${name}.fish" {source = toFishFunc val name;}) cfg.functions)
-      // (mapAttrs' (name: val: nameValuePair ".config/fish/conf.d/${name}.fish" {source = writeFish "${name}.fish" val;}) cfg.earlyConfigFiles);
+      // (mapAttrs' (name: val: nameValuePair "fish/functions/${name}.fish" {source = toFishFunc val name;}) cfg.functions)
+      // (mapAttrs' (name: val: nameValuePair "fish/conf.d/${name}.fish" {source = writeFish "${name}.fish" val;}) cfg.earlyConfigFiles);
   };
 }

--- a/modules/collection/programs/flameshot.nix
+++ b/modules/collection/programs/flameshot.nix
@@ -28,7 +28,7 @@ in {
         };
       };
       description = ''
-        Configuration written to {file}`$HOME/.config/flameshot/flameshot.ini`.
+        Configuration written to {file}`$XDG_CONFIG_HOME/flameshot/flameshot.ini`.
         Please reference [flameshot's example config] for config options.
 
         [flameshot's example config]: https://github.com/flameshot-org/flameshot/blob/master/flameshot.example.ini
@@ -38,7 +38,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/flameshot/flameshot.ini".source = mkIf (cfg.settings != {}) (
+    xdg.config.files."flameshot/flameshot.ini".source = mkIf (cfg.settings != {}) (
       ini.generate "flameshot.ini" cfg.settings
     );
   };

--- a/modules/collection/programs/foot.nix
+++ b/modules/collection/programs/foot.nix
@@ -40,7 +40,7 @@ in {
         };
       };
       description = ''
-        Settings are written as an INI file to {file}`$HOME/.config/foot/foot.ini`.
+        Settings are written as an INI file to {file}`$XDG_CONFIG_HOME/foot/foot.ini`.
 
         Refer to {manpage}`foot.ini(5)` or the [upstream template]
         for all available options.
@@ -52,7 +52,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/foot/foot.ini".source = mkIf (cfg.settings != {}) (
+    xdg.config.files."foot/foot.ini".source = mkIf (cfg.settings != {}) (
       ini.generate "foot.ini" cfg.settings
     );
   };

--- a/modules/collection/programs/fuzzel.nix
+++ b/modules/collection/programs/fuzzel.nix
@@ -36,7 +36,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/fuzzel/fuzzel.ini".source = mkIf (cfg.settings != {}) (
+    xdg.config.files."fuzzel/fuzzel.ini".source = mkIf (cfg.settings != {}) (
       ini.generate "fuzzel.ini" cfg.settings
     );
   };

--- a/modules/collection/programs/gammastep.nix
+++ b/modules/collection/programs/gammastep.nix
@@ -31,7 +31,7 @@ in {
         };
       };
       description = ''
-        Settings are written as an INI file to {file}`$HOME/.config/gammastep/config.ini`.
+        Settings are written as an INI file to {file}`$XDG_CONFIG_HOME/gammastep/config.ini`.
         Refer to [gammastep's example configuration] all available options.
 
         [gammastep's example configuration]: https://gitlab.com/chinstrap/gammastep/-/blob/master/gammastep.conf.sample
@@ -41,7 +41,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/gammastep/config.ini".source = mkIf (cfg.settings != {}) (
+    xdg.config.files."gammastep/config.ini".source = mkIf (cfg.settings != {}) (
       ini.generate "gammastep-config.ini" cfg.settings
     );
   };

--- a/modules/collection/programs/ghostty.nix
+++ b/modules/collection/programs/ghostty.nix
@@ -21,7 +21,7 @@
     mapAttrs'
     (name: value:
       nameValuePair
-      ".config/ghostty/themes/${name}"
+      "ghostty/themes/${name}"
       {
         source = keyValue.generate "ghostty-${name}-theme" value;
       })
@@ -56,7 +56,7 @@ in {
         ];
       };
       description = ''
-        The configuration converted to INI and written to {file}`$HOME/.config/ghostty/config`.
+        The configuration converted to INI and written to {file}`$XDG_CONFIG_HOME/ghostty/config`.
         Please consult [Ghostty's option reference]
         for configuration options.
 
@@ -106,9 +106,9 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files =
+    xdg.config.files =
       {
-        ".config/ghostty/config".source = mkIf (cfg.settings != {}) (
+        "ghostty/config".source = mkIf (cfg.settings != {}) (
           keyValue.generate "ghostty-config" cfg.settings
         );
       }

--- a/modules/collection/programs/git.nix
+++ b/modules/collection/programs/git.nix
@@ -51,7 +51,7 @@ in {
       '';
       description = ''
         Global user-level version of .gitignore written to
-        {file}`$HOME/.config/git/ignore`.
+        {file}`$XDG_CONFIG_HOME/git/ignore`.
       '';
     };
 
@@ -67,7 +67,7 @@ in {
       '';
       description = ''
         Global user-level version of .gitattributes written to
-        {file}`$HOME/.config/git/attributes`.
+        {file}`$XDG_CONFIG_HOME/git/attributes`.
       '';
     };
 
@@ -94,8 +94,8 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files = {
-      ".config/git/config".source = mkIf (cfg.settings != {} || cfg.integrations.difftastic.enable) (
+    xdg.config.files = {
+      "git/config".source = mkIf (cfg.settings != {} || cfg.integrations.difftastic.enable) (
         gitIni.generate "config" (
           cfg.settings
           // (let
@@ -108,8 +108,8 @@ in {
             })
         )
       );
-      ".config/git/ignore".text = mkIf (cfg.ignore != {}) cfg.ignore;
-      ".config/git/attributes".text = mkIf (cfg.attributes != {}) cfg.attributes;
+      "git/ignore".text = mkIf (cfg.ignore != {}) cfg.ignore;
+      "git/attributes".text = mkIf (cfg.attributes != {}) cfg.attributes;
     };
   };
 }

--- a/modules/collection/programs/helix.nix
+++ b/modules/collection/programs/helix.nix
@@ -14,7 +14,7 @@
   mkThemes = themes:
     mapAttrs' (
       name: value:
-        nameValuePair ".config/helix/themes/${name}.toml" {
+        nameValuePair "helix/themes/${name}.toml" {
           source = toml.generate "helix-theme-${name}.toml" value;
         }
     )
@@ -41,7 +41,7 @@ in {
       };
       description = ''
         The editor configuration converted into TOML and written to
-        {file}`$HOME/.config/helix/config.toml`. Please reference
+        {file}`$XDG_CONFIG_HOME/helix/config.toml`. Please reference
         [Helix's documentation] for config options.
 
         [Helix's documentation]: https://docs.helix-editor.com/editor.html
@@ -56,7 +56,7 @@ in {
       };
       description = ''
         The languages configurations converted into TOML and written to
-        {file}`$HOME/.config/helix/languages.toml`. Please reference
+        {file}`$XDG_CONFIG_HOME/helix/languages.toml`. Please reference
         [Helix's language documentation] for config options.
 
         [Helix's language documentation]: https://docs.helix-editor.com/languages.html
@@ -78,7 +78,7 @@ in {
       };
       description = ''
         The custom themes converted into TOML and written to
-        {file}`$HOME/.config/helix/themes/`. Please reference
+        {file}`$XDG_CONFIG_HOME/helix/themes/`. Please reference
         [Helix's theming documentation] for config options.
 
         [Helix's theming documentation]: https://docs.helix-editor.com/themes.html
@@ -90,11 +90,11 @@ in {
     packages = mkIf (cfg.package != null) [cfg.package];
     files =
       {
-        ".config/helix/config.toml".source = mkIf (cfg.settings != {}) (
+        "helix/config.toml".source = mkIf (cfg.settings != {}) (
           toml.generate "helix-config.toml" cfg.settings
         );
 
-        ".config/helix/languages.toml".source = mkIf (cfg.languages != {}) (
+        "helix/languages.toml".source = mkIf (cfg.languages != {}) (
           toml.generate "helix-languages.toml" cfg.languages
         );
       }

--- a/modules/collection/programs/hypridle.nix
+++ b/modules/collection/programs/hypridle.nix
@@ -50,7 +50,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/hypr/hypridle.conf".text = mkIf (cfg.settings != {}) (toHyprconf {
+    xdg.config.files."hypr/hypridle.conf".text = mkIf (cfg.settings != {}) (toHyprconf {
       attrs = cfg.settings;
     });
   };

--- a/modules/collection/programs/hyprlock.nix
+++ b/modules/collection/programs/hyprlock.nix
@@ -46,7 +46,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/hypr/hyprlock.conf".text = mkIf (cfg.settings != {}) (toHyprconf {
+    xdg.config.files."hypr/hyprlock.conf".text = mkIf (cfg.settings != {}) (toHyprconf {
       attrs = cfg.settings;
     });
   };

--- a/modules/collection/programs/keepassxc.nix
+++ b/modules/collection/programs/keepassxc.nix
@@ -34,7 +34,7 @@ in {
         };
       };
       description = ''
-        Settings are written as an INI file to {file}`$HOME/.config/keepassxc/keepassxc.ini`. Please reference
+        Settings are written as an INI file to {file}`$XDG_CONFIG_HOME/keepassxc/keepassxc.ini`. Please reference
         [KeePassXC's User Guide].
 
         It also can be configured by toggling options through the GUI, but this does not seem documented.
@@ -46,7 +46,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/keepassxc/keepassxc.ini".source = mkIf (cfg.settings != {}) (
+    xdg.config.files."keepassxc/keepassxc.ini".source = mkIf (cfg.settings != {}) (
       ini.generate "keepassxc.ini" cfg.settings
     );
   };

--- a/modules/collection/programs/kitty.nix
+++ b/modules/collection/programs/kitty.nix
@@ -29,7 +29,7 @@ in {
         font_family = "RobotoMono";
       };
       description = ''
-        Configuration written to {file}`$HOME/.config/kitty/kitty.conf`.
+        Configuration written to {file}`$XDG_CONFIG_HOME/kitty/kitty.conf`.
         Please reference [kitty's documentation] for config options.
 
         [kitty's documentation]: https://sw.kovidgoyal.net/kitty/conf/
@@ -42,7 +42,7 @@ in {
         default = null;
         example = "${pkgs.kitty-themes}/share/kitty-themes/themes/1984_light.conf";
         description = ''
-          Light theme to be linked to {file}`$HOME/.config/kitty/light-theme.auto.conf`.
+          Light theme to be linked to {file}`$XDG_CONFIG_HOME/kitty/light-theme.auto.conf`.
           This theme is set when your OS theme is set to light.
 
           Please reference [kitty-themes' repository] for available themes.
@@ -55,7 +55,7 @@ in {
         default = null;
         example = "${pkgs.kitty-themes}/share/kitty-themes/themes/1984_dark.conf";
         description = ''
-          Dark theme to be linked to {file}`$HOME/.config/kitty/dark-theme.auto.conf`.
+          Dark theme to be linked to {file}`$XDG_CONFIG_HOME/kitty/dark-theme.auto.conf`.
           This theme is set when your OS theme is set to dark.
 
           Please reference [kitty-themes' repository] for available themes.
@@ -68,7 +68,7 @@ in {
         default = null;
         example = "${pkgs.kitty-themes}/share/kitty-themes/themes/default.conf";
         description = ''
-          no-preference theme to be linked to {file}`$HOME/.config/kitty/no-preference-theme.auto.conf`.
+          no-preference theme to be linked to {file}`$XDG_CONFIG_HOME/kitty/no-preference-theme.auto.conf`.
           This theme is set when your OS does not specify any theme preference.
 
           Please reference [kitty-themes' repository] for available themes.
@@ -86,16 +86,16 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files = {
-      ".config/kitty/kitty.conf".source = mkIf (cfg.settings != {}) (
+    xdg.config.files = {
+      "kitty/kitty.conf".source = mkIf (cfg.settings != {}) (
         kittyKeyValue.generate "kitty.conf" (
           cfg.settings
           // optionalAttrs (cfg.integrations.fish.enable || cfg.integrations.zsh.enable) {shell_integration = "no-rc";}
         )
       );
-      ".config/kitty/light-theme.auto.conf".source = mkIf (cfg.theme.light != null) cfg.theme.light;
-      ".config/kitty/dark-theme.auto.conf".source = mkIf (cfg.theme.dark != null) cfg.theme.dark;
-      ".config/kitty/no-preference-theme.auto.conf".source = mkIf (cfg.theme.no-preference != null) cfg.theme.no-preference;
+      "kitty/light-theme.auto.conf".source = mkIf (cfg.theme.light != null) cfg.theme.light;
+      "kitty/dark-theme.auto.conf".source = mkIf (cfg.theme.dark != null) cfg.theme.dark;
+      "kitty/no-preference-theme.auto.conf".source = mkIf (cfg.theme.no-preference != null) cfg.theme.no-preference;
     };
 
     rum.programs.fish.config = mkIf cfg.integrations.fish.enable (

--- a/modules/collection/programs/lsd.nix
+++ b/modules/collection/programs/lsd.nix
@@ -26,7 +26,7 @@ in {
         };
       };
       description = ''
-        Configuration written to {file}`$HOME/.config/lsd/config.yaml`, defining lsd settings.
+        Configuration written to {file}`$XDG_CONFIG_HOME/lsd/config.yaml`, defining lsd settings.
         Please reference  [lsd's example configuration] to configure it accordingly.
 
         [lsd's example configuration]: https://github.com/lsd-rs/lsd#config-file-content
@@ -44,7 +44,7 @@ in {
         };
       };
       description = ''
-        Configuration written to {file}`$HOME/.config/lsd/icons.yaml`, defining the icons used by lsd.
+        Configuration written to {file}`$XDG_CONFIG_HOME/lsd/icons.yaml`, defining the icons used by lsd.
         Please reference [lsd's icon theme example] to configure it accordingly.
 
         [lsd's icon theme example]: https://github.com/lsd-rs/lsd#icon-theme
@@ -63,7 +63,7 @@ in {
         };
       };
       description = ''
-        Configuration written to {file}`$HOME/.config/lsd/colors.yaml`, defining the colors used by lsd.
+        Configuration written to {file}`$XDG_CONFIG_HOME/lsd/colors.yaml`, defining the colors used by lsd.
         Please reference [lsd's color theme example] to configure it accordingly.
 
         [lsd's color theme example]: https://github.com/lsd-rs/lsd#color-theme-file-content
@@ -73,13 +73,13 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/lsd/config.yaml".source = mkIf (cfg.settings != {}) (
+    xdg.config.files."lsd/config.yaml".source = mkIf (cfg.settings != {}) (
       yaml.generate "config.yaml" cfg.settings
     );
-    files.".config/lsd/icons.yaml".source = mkIf (cfg.icons != {}) (
+    xdg.config.files."lsd/icons.yaml".source = mkIf (cfg.icons != {}) (
       yaml.generate "icons.yaml" cfg.icons
     );
-    files.".config/lsd/colors.yaml".source = mkIf (cfg.colors != {}) (
+    xdg.config.files."lsd/colors.yaml".source = mkIf (cfg.colors != {}) (
       yaml.generate "colors.yaml" cfg.colors
     );
   };

--- a/modules/collection/programs/ncmpcpp.nix
+++ b/modules/collection/programs/ncmpcpp.nix
@@ -42,7 +42,7 @@ in {
         statusbar_visibility = true;
       };
       description = ''
-        Configuration written to {file}`$HOME/.config/ncmpcpp/config`.
+        Configuration written to {file}`$XDG_CONFIG_HOME/ncmpcpp/config`.
         Please reference {manpage}`ncmpcpp(1)` to configure it accordingly, or consult [ncmpcpp's example configuration].
 
         [ncmpcpp's example configuration]: https://github.com/ncmpcpp/ncmpcpp/blob/master/doc/config
@@ -53,7 +53,7 @@ in {
       type = attrsOf (listOf ncmpcppBindingType);
       default = {};
       description = ''
-        Custom bindings configuration written to {file}`$HOME/.config/ncmpcpp/bindings`.
+        Custom bindings configuration written to {file}`$XDG_CONFIG_HOME/ncmpcpp/bindings`.
         Please reference {manpage}`ncmpcpp(1)` to configure it accordingly, or consult
         [ncmpcpp's example bindings file].
 
@@ -91,9 +91,9 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files = {
-      ".config/ncmpcpp/config".text = mkIf (cfg.settings != {}) (toNcmpcppSettings cfg.settings);
-      ".config/ncmpcpp/bindings".text = mkIf (cfg.bindings != {}) (toNcmpcppBinding cfg.bindings);
+    xdg.config.files = {
+      "ncmpcpp/config".text = mkIf (cfg.settings != {}) (toNcmpcppSettings cfg.settings);
+      "ncmpcpp/bindings".text = mkIf (cfg.bindings != {}) (toNcmpcppBinding cfg.bindings);
     };
   };
 }

--- a/modules/collection/programs/nushell.nix
+++ b/modules/collection/programs/nushell.nix
@@ -67,7 +67,7 @@ in {
       description = ''
         A set of options for nushell, flattened, prepended with `$env.config` to avoid overwriting
         (tables of config are overwritten if they occupy the same namespace). It is then written
-        to {file}`$HOME/.config/nushell/config.nu`.
+        to {file}`$XDG_CONFIG_HOME/nushell/config.nu`.
 
         Please see [The Nushell Book] for configuration options.
 
@@ -84,7 +84,7 @@ in {
       };
       description = ''
         A set of aliases for nushell, converted into nu and written to
-        {file}`$HOME/.config/nushell/config.nu`. Please note that we cannot
+        {file}`$XDG_CONFIG_HOME/nushell/config.nu`. Please note that we cannot
         handle complex aliases that use `def` at this time.
 
         Please see [The Nushell Book] for a simple tutorial.
@@ -123,7 +123,7 @@ in {
         }
       '';
       description = ''
-        Extra configuration to be written to {file}`$HOME/.config/nushell/config.nu`.
+        Extra configuration to be written to {file}`$XDG_CONFIG_HOME/nushell/config.nu`.
 
         Please see [The Nushell Book] for more info.
 
@@ -137,9 +137,9 @@ in {
       description = ''
         [The Nushell Book]: https://www.nushell.sh/book/configuration.html
 
-        Extra configuration to be written to {file}`$HOME/.config/nushell/env.nu`.
+        Extra configuration to be written to {file}`$XDG_CONFIG_HOME/nushell/env.nu`.
         Please keep in mind that the upstream documentation generally advises against
-        writing to this file, and instead suggests using {file}`$HOME/.config/nushell/config.nu`.
+        writing to this file, and instead suggests using {file}`$XDG_CONFIG_HOME/nushell/config.nu`.
 
         See [The Nushell Book] for more info.
 
@@ -151,7 +151,7 @@ in {
       default = "";
       description = ''
         Nushell may be used as a login shell, so this option writes to
-        {file}`$HOME/.config/nushell/login.nu` to allow you to configure
+        {file}`$XDG_CONFIG_HOME/nushell/login.nu` to allow you to configure
         nushell as your login shell.
 
         Please recognize that this is mainly for advanced users and is not
@@ -165,7 +165,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = [cfg.package];
-    files = let
+    xdg.config.files = let
       checks = {
         settings = cfg.settings != {};
         aliases = cfg.aliases != {};
@@ -173,7 +173,7 @@ in {
         variables = config.environment.sessionVariables != {};
       };
     in {
-      ".config/nushell/config.nu".text = mkIf (checks.settings || checks.aliases || checks.extraConfig || checks.variables) (
+      "nushell/config.nu".text = mkIf (checks.settings || checks.aliases || checks.extraConfig || checks.variables) (
         concatStringsSep "\n" [
           (optionalString checks.settings (nu.generate.config cfg.settings))
           (optionalString checks.aliases (nu.generate.aliases cfg.aliases))
@@ -181,11 +181,11 @@ in {
           cfg.extraConfig
         ]
       );
-      ".config/nushell/env.nu".text = mkIf (cfg.envFile != "") cfg.envFile;
+      "nushell/env.nu".text = mkIf (cfg.envFile != "") cfg.envFile;
 
       # from https://github.com/nushell/nushell/discussions/12997#discussioncomment-9638977
       # also used in home manager
-      ".config/nushell/plugin.msgpackz".source = mkIf (cfg.plugins != []) (
+      "nushell/plugin.msgpackz".source = mkIf (cfg.plugins != []) (
         let
           msgPackz = pkgs.runCommand "nuPlugin-msgPackz" {} ''
             mkdir -p "$out"
@@ -197,7 +197,7 @@ in {
           '';
         in "${msgPackz}/plugin.msgpackz"
       );
-      ".config/nushell/login.nu".text = mkIf (cfg.loginFile != "") cfg.loginFile;
+      "nushell/login.nu".text = mkIf (cfg.loginFile != "") cfg.loginFile;
     };
   };
 }

--- a/modules/collection/programs/spotify-player.nix
+++ b/modules/collection/programs/spotify-player.nix
@@ -50,7 +50,7 @@ in {
       };
       description = ''
         The configuration converted into TOML and written to
-        {file}`$HOME/.config/spotify-player/app.toml`.
+        {file}`$XDG_CONFIG_HOME/spotify-player/app.toml`.
 
         Please reference [spotify_player's configuration documentation]
         for configuration options.
@@ -101,7 +101,7 @@ in {
       ];
       description = ''
         The theme converted into TOML and written to
-        {file}`$HOME/.config/spotify-player/themes.toml`.
+        {file}`$XDG_CONFIG_HOME/spotify-player/themes.toml`.
 
         Please reference [spotify_player's theme documentation]
         for configuration options.
@@ -129,7 +129,7 @@ in {
       };
       description = ''
         Sets of keymaps and actions converted into TOML and written to
-        {file}`$HOME/.config/spotify-player/keymap.toml`.
+        {file}`$XDG_CONFIG_HOME/spotify-player/keymap.toml`.
         See example for how to format declarations.
 
         Please reference [spotify_player's keymaps documentation]
@@ -142,17 +142,17 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files = {
-      ".config/spotify-player/app.toml".source = mkIf (cfg.settings != {}) (
+    xdg.config.files = {
+      "spotify-player/app.toml".source = mkIf (cfg.settings != {}) (
         toml.generate "spotify-player/app.toml" cfg.settings
       );
 
       # Passes each declared theme under the "themes" attr as needed
-      ".config/spotify-player/theme.toml".source = mkIf (cfg.themes != []) (
+      "spotify-player/theme.toml".source = mkIf (cfg.themes != []) (
         toml.generate "spotify-player/theme.toml" {inherit (cfg) themes;}
       );
 
-      ".config/spotify-player/keymap.toml".source = mkIf (cfg.keymap != {}) (
+      "spotify-player/keymap.toml".source = mkIf (cfg.keymap != {}) (
         toml.generate "spotify-player/keymap.toml" cfg.keymap
       );
     };

--- a/modules/collection/programs/starship.nix
+++ b/modules/collection/programs/starship.nix
@@ -35,7 +35,7 @@ in {
       };
 
       description = ''
-        The configuration converted to TOML and written to {file}`$HOME/.config/starship.toml`.
+        The configuration converted to TOML and written to {file}`$XDG_CONFIG_HOME/starship.toml`.
         Please reference [Starship's documentation] for configuration options.
 
         [Starship's documentation]: https://starship.rs/config
@@ -53,7 +53,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/starship.toml".source = mkIf (cfg.settings != {}) (
+    xdg.config.files."starship.toml".source = mkIf (cfg.settings != {}) (
       toml.generate "starship.toml" cfg.settings
     );
 

--- a/modules/collection/programs/tealdeer.nix
+++ b/modules/collection/programs/tealdeer.nix
@@ -25,7 +25,7 @@ in {
         };
       };
       description = ''
-        Configuration written to {file}`$HOME/.config/tealdeer/config.toml`.
+        Configuration written to {file}`$XDG_CONFIG_HOME/tealdeer/config.toml`.
         Please reference [tealdeer's documentation] for config options.
 
         [tealdeer's documentation]: https://tealdeer-rs.github.io/tealdeer/config.html
@@ -35,7 +35,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/tealdeer/config.toml".source = mkIf (cfg.settings != {}) (
+    xdg.config.files."tealdeer/config.toml".source = mkIf (cfg.settings != {}) (
       toml.generate "tealdeer-config.toml" cfg.settings
     );
   };

--- a/modules/collection/programs/tofi.nix
+++ b/modules/collection/programs/tofi.nix
@@ -27,7 +27,7 @@ in {
       };
       description = ''
         The configuration converted into "key = value" and written to
-        {file}`$HOME/.config/tofi/config`. Please reference
+        {file}`$XDG_CONFIG_HOME/tofi/config`. Please reference
         {manpage}`tofi(5)`, or see an example at
         [tofi's default configuration].
 
@@ -38,6 +38,6 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files.".config/tofi/config".text = mkIf (cfg.settings != {}) (toKeyValue cfg.settings);
+    xdg.config.files."tofi/config".text = mkIf (cfg.settings != {}) (toKeyValue cfg.settings);
   };
 }

--- a/modules/collection/programs/vscode.nix
+++ b/modules/collection/programs/vscode.nix
@@ -27,7 +27,7 @@ in {
       };
       description = ''
         The configuration converted into JSON and written to
-        {file}`$HOME/.config/Code/User/settings.json`.
+        {file}`$XDG_CONFIG_HOME/Code/User/settings.json`.
 
         Please reference [Visual Studio Code's official documentation]
         for more information.
@@ -39,8 +39,8 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files = {
-      ".config/Code/User/settings.json".source = mkIf (cfg.settings != {}) (
+    xdg.config.files = {
+      "Code/User/settings.json".source = mkIf (cfg.settings != {}) (
         json.generate "settings.json" cfg.settings
       );
     };

--- a/modules/collection/programs/zoxide.nix
+++ b/modules/collection/programs/zoxide.nix
@@ -43,17 +43,19 @@ in {
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != true) [cfg.package];
     files = {
+      ".zshrc".text = mkIf (config.rum.programs.zsh.enable && cfg.integrations.zsh.enable) (
+        mkAfter ''eval "$(${getExe cfg.package} init zsh ${toFlags})"''
+      );
+    };
+    xdg.config.files = {
       /*
       Needs to be added to the end of the shell configuration files, hence the `mkIf` and `mkAfter`.
       https://github.com/ajeetdsouza/zoxide#installation
       */
-      ".config/fish/config.fish".text = mkIf (config.rum.programs.fish.enable && cfg.integrations.fish.enable) (
+      "fish/config.fish".text = mkIf (config.rum.programs.fish.enable && cfg.integrations.fish.enable) (
         mkAfter "${getExe cfg.package} init fish ${toFlags} | source"
       );
-      ".zshrc".text = mkIf (config.rum.programs.zsh.enable && cfg.integrations.zsh.enable) (
-        mkAfter ''eval "$(${getExe cfg.package} init zsh ${toFlags})"''
-      );
-      ".config/nushell/config.nu".text = mkIf (config.rum.programs.nushell.enable && cfg.integrations.nushell.enable) (
+      "nushell/config.nu".text = mkIf (config.rum.programs.nushell.enable && cfg.integrations.nushell.enable) (
         mkAfter ''
           source ${
             pkgs.runCommand "zoxide-init-nu" {} ''${getExe cfg.package} init nushell ${toFlags} >> "$out"''


### PR DESCRIPTION
Title. This makes our modules respect `XDG_CONFIG_HOME` (see feel-co/hjem#45).

This introduces breaking changes, as older versions of hjem will not have `xdg.config.files` available, an admonition has been added to the README mentioning the pull request.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
