### PR TITLE
desktops/niri: add missing option descriptions; fix typos

### DIFF
--- a/modules/collection/desktops/niri.nix
+++ b/modules/collection/desktops/niri.nix
@@ -94,7 +94,7 @@
         description = ''
           [niri's wiki]: https://github.com/YaLTeR/niri/wiki/Configuration:-Key-Bindings
 
-          The paramaters to append to the bind. See [niri's wiki] for a complete list.
+          The parameters to append to the bind. See [niri's wiki] for a complete list.
         '';
       };
     };
@@ -122,6 +122,11 @@ in {
           };
         };
       };
+      description = ''
+        [niri's wiki]: https://github.com/YaLTeR/niri/wiki/Configuration:-Key-Bindings
+
+        A list of key bindings that will be added to the configuration file. See [niri's wiki] for a complete list.
+      '';
     };
     spawn-at-startup = mkOption {
       type = listOf (listOf str);
@@ -131,6 +136,11 @@ in {
           ["waybar"]
           ["${getExe pkgs.alacritty}" "-e" "fish"]
         ]
+      '';
+      description = ''
+        [niri's wiki]: https://github.com/YaLTeR/niri/wiki/Configuration:-Miscellaneous
+
+        A list of programs to be loaded with niri on startup. see [niri's wiki] for more details on the API.
       '';
     };
     extraVariables = mkOption {


### PR DESCRIPTION
Added missing options descriptions to the niri module, and fixed a typo. Also uncapitalized niri because in their repo, it seems like they only capitalize it at beginning of sentences, so I thought it best to follow their conventions.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [x] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
