### PR TITLE
desktops/niri: use package option and make nullable

### DIFF
--- a/modules/collection/desktops/niri.nix
+++ b/modules/collection/desktops/niri.nix
@@ -8,8 +8,8 @@
   inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf;
-  inherit (lib.options) mkEnableOption mkOption literalExpression;
-  inherit (lib.strings) concatMapStringsSep;
+  inherit (lib.options) mkEnableOption mkOption literalExpression mkPackageOption;
+  inherit (lib.strings) concatMapStringsSep optionalString;
   inherit (lib.trivial) pipe boolToString;
   inherit (lib.types) listOf path attrsOf anything str lines submodule nullOr;
 
@@ -104,6 +104,13 @@
 in {
   options.rum.desktops.niri = {
     enable = mkEnableOption "niri: A scrollable-tiling Wayland compositor";
+    package = mkPackageOption pkgs "niri" {
+      nullable = true;
+      extraDescription = ''
+        Only used to validate the generated config file. Set to `null` to
+        disable the check phase.
+      '';
+    };
     binds = mkOption {
       type = attrsOf bindsModule;
       default = {};
@@ -232,8 +239,8 @@ in {
           ]
         ))
       ];
-      checkPhase = ''
-        ${getExe pkgs.niri} validate -c "$file"
+      checkPhase = optionalString (cfg.package != null) ''
+        ${getExe cfg.package} validate -c "$file"
       '';
     };
   };

--- a/modules/tests/collection/desktops/niri.nix
+++ b/modules/tests/collection/desktops/niri.nix
@@ -1,6 +1,23 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkForce;
+in {
   name = "desktops-niri";
   nodes.machine = {
+    specialisation.nullPackage.configuration = {
+      hjem.users.bob = {
+        clobberFiles = mkForce true; # Enable clobber to clobber the generated file
+        rum.desktops.niri = {
+          # Create an action that is valid in the module but invalid in niri.
+          # This ensures that the check phase is indeed skipped.
+          binds."Mod+9".action = "bad-action";
+          package = null;
+        };
+      };
+    };
     hjem.users.bob = {
       environment.sessionVariables = {
         RUM_TEST = "HEY";
@@ -55,7 +72,10 @@
   # that our abstracted options are writing to that generated file, otherwise
   # we could run into a case where the file is valid but some of our settings
   # aren't actually being written and tested.
-  testScript =
+  testScript = {nodes, ...}: let
+    baseSystem = nodes.machine.system.build.toplevel;
+    specialisations = "${baseSystem}/specialisation";
+  in
     #python
     ''
       config = "/home/bob/.config/niri/config.kdl"
@@ -94,5 +114,9 @@
       with subtest("Validate plain file writing"):
         machine.succeed("grep 'open-maximized true' %s" % config)
         machine.succeed("grep 'lid-close' %s" % config)
+
+      with subtest("Validate skipping check phase"):
+        machine.succeed("${specialisations}/nullPackage/bin/switch-to-configuration test")
+        machine.succeed("grep 'bad-action' %s" % config)
     '';
 }


### PR DESCRIPTION
Quick pr to add a package option that is needed for users not using the package from nixpkgs. It can also be set to null that disables the check phase of the generated config file.

Related Issue(s): \<None\>

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open