### PR TITLE
programs/helix: add `xdg.config.files`

### DIFF
--- a/modules/collection/programs/helix.nix
+++ b/modules/collection/programs/helix.nix
@@ -88,7 +88,7 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    files =
+    xdg.config.files =
       {
         "helix/config.toml".source = mkIf (cfg.settings != {}) (
           toml.generate "helix-config.toml" cfg.settings


### PR DESCRIPTION
This fixes Helix using `files` instead of `xdg.config.files`, as it slipped under the radar during the migration and now links files into `$HOME/helix` incorrectly.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
