### PR TITLE
Prepare docs for helpers

### DIFF
--- a/docs/package.nix
+++ b/docs/package.nix
@@ -3,81 +3,86 @@
   pkgs,
   lib,
   rumLib,
+  inputs,
 }: let
   inherit (builtins) isAttrs toString;
   inherit (lib.attrsets) isDerivation mapAttrs optionalAttrs;
-  inherit (lib.filesystem) listFilesRecursive;
   inherit (lib.modules) mkForce evalModules;
   inherit (lib.options) mkOption;
   inherit (lib.strings) hasPrefix removePrefix;
   inherit (lib.trivial) pipe;
 
+  removePrefixes = prefixes: str: pipe str (map removePrefix prefixes);
+
+  evaluatedModules = evalModules {
+    specialArgs = {inherit rumLib;};
+    modules =
+      [
+        {
+          imports = [inputs.hjem.nixosModules.default];
+          hjem.extraModules = [inputs.self.hjemModules.default];
+        }
+      ]
+      ++ [
+        (
+          let
+            # From nixpkgs:
+            #
+            # Recursively replace each derivation in the given attribute set
+            # with the same derivation but with the `outPath` attribute set to
+            # the string `"\${pkgs.attribute.path}"`. This allows the
+            # documentation to refer to derivations through their values without
+            # establishing an actual dependency on the derivation output.
+            #
+            # This is not perfect, but it seems to cover a vast majority of use cases.
+            #
+            # Caveat: even if the package is reached by a different means, the
+            # path above will be shown and not e.g.
+            # `${config.services.foo.package}`.
+            scrubDerivations = namePrefix: pkgSet:
+              mapAttrs (
+                name: value: let
+                  wholeName = "${namePrefix}.${name}";
+                in
+                  if isAttrs value
+                  then
+                    scrubDerivations wholeName value
+                    // optionalAttrs (isDerivation value) {
+                      inherit (value) drvPath;
+                      outPath = "\${${wholeName}}";
+                    }
+                  else value
+              )
+              pkgSet;
+          in {
+            _module = {
+              check = false;
+              args.pkgs = mkForce (scrubDerivations "pkgs" pkgs);
+            };
+          }
+        )
+        # avoid having `_module.args` in the documentation
+        {
+          options = {
+            _module.args = mkOption {
+              internal = true;
+            };
+          };
+        }
+      ];
+  };
   configJSON =
     (pkgs.nixosOptionsDoc {
       variablelistId = "hjr-options";
       warningsAreErrors = true;
-
-      inherit
-        (
-          (evalModules {
-            specialArgs = {inherit rumLib;};
-            modules =
-              (listFilesRecursive ../modules/collection)
-              ++ [
-                (
-                  let
-                    # From nixpkgs:
-                    #
-                    # Recursively replace each derivation in the given attribute set
-                    # with the same derivation but with the `outPath` attribute set to
-                    # the string `"\${pkgs.attribute.path}"`. This allows the
-                    # documentation to refer to derivations through their values without
-                    # establishing an actual dependency on the derivation output.
-                    #
-                    # This is not perfect, but it seems to cover a vast majority of use cases.
-                    #
-                    # Caveat: even if the package is reached by a different means, the
-                    # path above will be shown and not e.g.
-                    # `${config.services.foo.package}`.
-                    scrubDerivations = namePrefix: pkgSet:
-                      mapAttrs (
-                        name: value: let
-                          wholeName = "${namePrefix}.${name}";
-                        in
-                          if isAttrs value
-                          then
-                            scrubDerivations wholeName value
-                            // optionalAttrs (isDerivation value) {
-                              inherit (value) drvPath;
-                              outPath = "\${${wholeName}}";
-                            }
-                          else value
-                      )
-                      pkgSet;
-                  in {
-                    _module = {
-                      check = false;
-                      args.pkgs = mkForce (scrubDerivations "pkgs" pkgs);
-                    };
-                  }
-                )
-                # avoid having `_module.args` in the documentation
-                {
-                  options = {
-                    _module.args = mkOption {
-                      internal = true;
-                    };
-                  };
-                }
-              ];
-          })
-        )
-        options
-        ;
+      options = (evaluatedModules.options.hjem.users.type.getSubOptions []).rum;
 
       transformOptions = opt:
         opt
         // {
+          # This is needed, as otherwise, every option will be prefixed with `<name>.rum`
+          name = removePrefixes ["<name>."] opt.name;
+
           declarations =
             map (
               decl:

--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         "smfh": "smfh"
       },
       "locked": {
-        "lastModified": 1754244549,
-        "narHash": "sha256-ByZ81/QttgSS1mQYttnaoMw2WnqMvQ6HCxBPOioKrOA=",
+        "lastModified": 1756255328,
+        "narHash": "sha256-WJ70Dv+tJjIl7mMOqUgcdcz+RrujDRoeKptiU6oh1lI=",
         "owner": "feel-co",
         "repo": "hjem",
-        "rev": "ee5c671eeba5cddd94f2c7de3c36f019fae5854e",
+        "rev": "2426d6ad20e767895e936ed0c9563cc4e2b6c96f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,9 @@
     nixpkgs,
     treefmt-nix,
     ndg,
+    hjem,
     ...
-  }: let
+  } @ inputs: let
     supportedSystems = ["x86_64-linux" "aarch64-linux"];
 
     forAllSystems = function:
@@ -32,6 +33,7 @@
       (system: function nixpkgs.legacyPackages.${system});
 
     rumLib = import ./modules/lib/default.nix {inherit (nixpkgs) lib;};
+
     treefmtEval = forAllSystems (pkgs:
       treefmt-nix.lib.evalModule pkgs
       {
@@ -49,6 +51,7 @@
       hjem-rum = import ./modules/hjem.nix {
         inherit (nixpkgs) lib;
         inherit rumLib;
+        inherit inputs;
       };
       default = self.hjemModules.hjem-rum;
     };
@@ -56,6 +59,7 @@
       docs = pkgs.callPackage ./docs/package.nix {
         inherit (ndg.packages.${pkgs.system}) ndg;
         inherit rumLib;
+        inherit inputs;
       };
     });
     lib = rumLib;

--- a/modules/hjem.nix
+++ b/modules/hjem.nix
@@ -1,6 +1,7 @@
 {
   lib,
   rumLib,
+  inputs,
 }: {
   # Import the Hjem Rum module collection as an extraModule available under `hjem.users.<username>`
   # This allows the definition of rum modules under `hjem.users.<username>.rum`
@@ -8,7 +9,9 @@
   # Import the collection modules recursively so that all files
   # are imported. This then gets imported into the user's
   # 'hjem.extraModules' to make them available under 'hjem.users.<username>'
-  imports = lib.filesystem.listFilesRecursive ./collection;
+  imports =
+    [inputs.hjem.nixosModules.hjem-lib]
+    ++ lib.filesystem.listFilesRecursive ./collection;
 
   _module.args.rumLib = rumLib;
 }


### PR DESCRIPTION
This PR prepares the documentation generation for usage of the new Hjem lib, as of feel-co/hjem#54. This is a prerequisite for related issues, and will require the upstream PR to be merged first.

The way this is achieved is by evaluating our module system as a Hjem extra module, exactly the same as it would be in a regular NixOS configuration, and then stripped of unnecessary prefixes in `transformOptions`. This additionally allows us to reproduce the exact same environment that would be on an end-user machine, which wasn't the case as we used to import the module as a regular NixOS module.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): #127 

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
