### PR TITLE
docs/website: fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [#17]: https://github.com/snugnug/hjem-rum/issues/17
 [@eclairevoyant]: https://github.com/eclairevoyant
 [@NotAShelf]: https://github.com/NotAShelf
-[documentation]: snugnug.github.io/hjem-rum/
+[documentation]: https://snugnug.github.io/hjem-rum/
 
 A module collection for managing your `$HOME` with [Hjem].
 


### PR DESCRIPTION
Fix documentation link, protocol was missing.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): #73 

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open
   - There is a conflicting PR (#115), but considering the link has been broken since fcad99861c9f24f4c32ac7cae1f00d4b6fb9ba0c it might make sense to merge this PR

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
