### PR TITLE
programs/fish: escape env abbrs and alias name and values

### DIFF
--- a/modules/collection/programs/fish.nix
+++ b/modules/collection/programs/fish.nix
@@ -190,18 +190,15 @@ in {
         "fish/config.fish" = mkIf (cfg.config != "") {source = writeFish "config.fish" cfg.config;};
         "fish/conf.d/rum-environment-variables.fish" = mkIf (env != {}) {
           text = ''
-            ${concatMapAttrsStringSep "\n" (name: value: "set --global --export ${name} ${toString value}") env}
-          '';
+            ${concatMapAttrsStringSep "\n" (name: value: "set --global --export ${escapeShellArg name} ${escapeShellArg (toString value)}") env}          '';
         };
         "fish/conf.d/rum-abbreviations.fish" = mkIf (cfg.abbrs != {}) {
           text = ''
-            ${concatMapAttrsStringSep "\n" (name: value: "abbr --add -- ${name} ${escapeShellArg (toString value)}") cfg.abbrs}
-          '';
+            ${concatMapAttrsStringSep "\n" (name: value: "abbr --add -- ${escapeShellArg name} ${escapeShellArg (toString value)}") cfg.abbrs}          '';
         };
         "fish/conf.d/rum-aliases.fish" = mkIf (cfg.aliases != {}) {
           text = ''
-            ${concatMapAttrsStringSep "\n" (name: value: "alias -- ${name} ${escapeShellArg (toString value)}") cfg.aliases}
-          '';
+            ${concatMapAttrsStringSep "\n" (name: value: "alias -- ${escapeShellArg name} ${escapeShellArg (toString value)}") cfg.aliases}          '';
         };
       }
       // (mapAttrs' (name: val: nameValuePair "fish/functions/${name}.fish" {source = toFishFunc val name;}) cfg.functions)


### PR DESCRIPTION
This allows fish to give a proper error message instead of silently failing and the user potentially running unwanted commands.

[Please write the content and purpose of your changes here.]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
