### PR TITLE
Revert "misc/gtk: move gtkrc-2.0"

### DIFF
--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   inherit (lib.options) literalExpression mkOption mkEnableOption;
-  inherit (lib.types) listOf package lines str path;
+  inherit (lib.types) listOf package lines str;
   inherit (lib.modules) mkIf mkRenamedOptionModule;
   inherit (lib.lists) optionals;
   inherit (lib.attrsets) optionalAttrs;
@@ -58,17 +58,6 @@ in {
         [official GTK documentation]: https://docs.gtk.org/gtk3/class.Settings.html
       '';
     };
-    gtk2Location = mkOption {
-      type = path;
-      default = ".gtkrc-2.0";
-      defaultText = "$HOME/.gtkrc-2.0";
-      example = ".config/gtk-2.0/gtkrc";
-      description = ''
-        The location relative to {env}`$HOME` to write the GTK-2.0 settings to.
-        By default, apps search at {file}`$HOME/.gtkrc-2.0`, but the environmental
-        variable {env}`GTK2_RC_FILES` can be set to a different location.
-      '';
-    };
     css = {
       gtk3 = mkOption {
         type = lines;
@@ -117,12 +106,12 @@ in {
     inherit (cfg) packages;
 
     files = optionalAttrs (cfg.settings != {}) {
-      ${cfg.gtk2Location}.text = toGtk2Text {inherit (cfg) settings;};
+      ".gtkrc-2.0".text = toGtk2Text {inherit (cfg) settings;};
     };
     xdg.config.files = (
       optionalAttrs (cfg.settings != {}) {
-        ".config/gtk-3.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
-        ".config/gtk-4.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
+        "gtk-3.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
+        "gtk-4.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
       }
       // optionalAttrs (cfg.css.gtk3 != "") {
         "gtk-3.0/gtk.css".text = cfg.css.gtk3;
@@ -137,7 +126,7 @@ in {
 
     # Set sessionVariables to load
     environment.sessionVariables = {
-      GTK2_RC_FILES = "${config.directory}/${cfg.gtk2Location}";
+      GTK2_RC_FILES = "${config.directory}/.gtkrc-2.0";
       GTK_THEME = mkIf (hasAttr "theme-name" cfg.settings) cfg.settings.theme-name;
     };
   };


### PR DESCRIPTION
Reverts snugnug/hjem-rum#118, as in the path type expects an absolute path so the type will not work with our use-case and breaks Hjem for everyone. I apologize for merging this, I thought the path type would work here.

I believe we do have to run asserts to check if it's a path-like string, but we cannot use the path type