### PR TITLE
programs/winboat: init module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -78,11 +78,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754498491,
-        "narHash": "sha256-erbiH2agUTD0Z30xcVSFcDHzkRvkRXOQ3lb887bcVrs=",
+        "lastModified": 1761114652,
+        "narHash": "sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d+dAiC3H+CDle4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c2ae88e026f9525daf89587f3cbee584b92b6134",
+        "rev": "01f116e4df6a15f4ccdffb1bcd41096869fb385c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
         default = pkgs.mkShell {
           packages = with pkgs; [
             pre-commit
-            python312Packages.commitizen
+            commitizen
           ];
           inputsFrom = [
             treefmtEval.${pkgs.system}.config.build.devShell

--- a/modules/collection/programs/winboat.nix
+++ b/modules/collection/programs/winboat.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
+
+  json = pkgs.formats.json {};
+
+  cfg = config.rum.programs.winboat;
+in {
+  options.rum.programs.winboat = {
+    enable = mkEnableOption "WinBoat";
+
+    package = mkPackageOption pkgs "winboat" {nullable = true;};
+
+    settings = mkOption {
+      inherit (json) type;
+      default = {};
+      example = {
+        customApps = [
+          {
+            Name = "Bob's favourite app";
+            Path = "C:\\Users\\bob\\Downloads\\App\\app.exe";
+            Source = "custom";
+          }
+        ];
+        experimentalFeatures = true;
+        rdpMonitoringEnabled = false;
+      };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/winboat/winboat.config.json`.
+        As of writing, there aren't any docs for the available configuration options,
+        but please refer the configuration types in [this file] for config options.
+
+        [this file]: https://github.com/TibixDev/winboat/blob/main/src/renderer/lib/config.ts
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    packages = mkIf (cfg.package != null) [cfg.package];
+
+    xdg.config.files."winboat/winboat.config.json" = mkIf (cfg.settings != {}) {
+      source = json.generate "winboat-config.json" cfg.settings;
+    };
+  };
+}

--- a/modules/tests/collection/programs/winboat.nix
+++ b/modules/tests/collection/programs/winboat.nix
@@ -1,0 +1,32 @@
+{
+  name = "programs-winboat";
+  nodes.machine = {
+    hjem.users.bob.rum = {
+      programs.winboat = {
+        enable = true;
+        settings = {
+          customApps = [
+            {
+              Name = "Bob's favourite app";
+              Path = "C:\\Users\\bob\\Downloads\\App\\app.exe";
+              Source = "custom";
+            }
+          ];
+          experimentalFeatures = true;
+          rdpMonitoringEnabled = false;
+        };
+      };
+    };
+  };
+
+  testScript =
+    #python
+    ''
+      # Waiting for our user to load.
+      machine.succeed("loginctl enable-linger bob")
+      machine.wait_for_unit("default.target")
+
+      # Checks if the winboat config file exists in the expected place.
+      machine.succeed("[ -r %s ]" % "/home/bob/.config/winboat")
+    '';
+}


### PR DESCRIPTION
WinBoat is beta, so the config options and location could change in the future. But it should be fine to have a simple module with just settings.

Note that the test is very basic, it only checks if the file was placed correctly. I don't know what else to test for.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [x] Followed the general API laid out in CONTRIBUTING.md
- [x] Wrote tests (or expressed a need for help on tests)
