### PR TITLE
programs/gammastep: add systemd service

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,17 +35,20 @@
     },
     "hjem": {
       "inputs": {
+        "ndg": [
+          "ndg"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],
         "smfh": "smfh"
       },
       "locked": {
-        "lastModified": 1756255328,
-        "narHash": "sha256-WJ70Dv+tJjIl7mMOqUgcdcz+RrujDRoeKptiU6oh1lI=",
+        "lastModified": 1760829577,
+        "narHash": "sha256-X2aK1KxxqmS4yXf+svpuae/niHfHPU5Z25yFke/Q5kE=",
         "owner": "feel-co",
         "repo": "hjem",
-        "rev": "2426d6ad20e767895e936ed0c9563cc4e2b6c96f",
+        "rev": "3c01274451544d3f5ebceec382447c46cb9ca83c",
         "type": "github"
       },
       "original": {
@@ -124,11 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747622321,
-        "narHash": "sha256-W0dYIWgsUu6rvOJRtKLhKskkv0VhQhJYGNIq+gGUc8g=",
+        "lastModified": 1759113356,
+        "narHash": "sha256-xm4kEUcV2jk6u15aHazFP4YsMwhq+PczA+Ul/4FDKWI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bd030fd9983f7fddf87be1c64aa3064c8afa24c4",
+        "rev": "be3b8843a2be2411500f6c052876119485e957a2",
         "type": "github"
       },
       "original": {
@@ -147,11 +150,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1749906619,
-        "narHash": "sha256-/9Ww10kYopxfCNNnNDwENTubs7Wzqlw+O6PJAHNOYQw=",
+        "lastModified": 1760525934,
+        "narHash": "sha256-1HtxuA45R/jExzE9iuimuECHWbV2c+CBdJmr/RtluaI=",
         "owner": "feel-co",
         "repo": "smfh",
-        "rev": "39f5c06153f63100376bc607b1465850b6df77fd",
+        "rev": "7123a00cc3c3e90ba703a37ca8d997be95c62d99",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     hjem = {
       url = "github:feel-co/hjem";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.ndg.follows = "ndg";
     };
     ndg = {
       url = "github:feel-co/ndg";

--- a/modules/collection/programs/gammastep.nix
+++ b/modules/collection/programs/gammastep.nix
@@ -44,5 +44,17 @@ in {
     xdg.config.files."gammastep/config.ini" = mkIf (cfg.settings != {}) {
       source = ini.generate "gammastep-config.ini" cfg.settings;
     };
+
+    systemd.services.gammastep = {
+      after = ["graphical-session.target"];
+      description = "Screen color temperature manager";
+      documentation = ["https://gitlab.com/chinstrap/gammastep"];
+      partOf = ["graphical-session.target"];
+      serviceConfig = {
+        ExecStart = lib.getExe pkgs.gammastep;
+        Restart = "on-failure";
+      };
+      wantedBy = ["graphical-session.target"];
+    };
   };
 }


### PR DESCRIPTION
Adds [`gammastep.service`](https://gitlab.com/chinstrap/gammastep/-/blob/master/data/systemd/gammastep.service.in)

Note:
- I haven't added its sister service [`gammastep-indicator.service`](https://gitlab.com/chinstrap/gammastep/-/blob/master/data/systemd/gammastep-indicator.service.in).
- I don't know much about systemd stuff so please nit if something's wrong or missing.
- This is the first time a systemd service is being added, I'm not sure what the guidelines are. Do we need tests? What kind of tests?
- My other PR, #147, conflicts with this PR since it updates the lock file (or maybe not if the nixpkgs bump is distinguishable)

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [x] Followed the general API laid out in CONTRIBUTING.md
- [x] Wrote tests (or expressed a need for help on tests)
