### PR TITLE
modules/gtk: fix type check on gtk2Location

### DIFF
--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   inherit (lib.options) literalExpression mkOption mkEnableOption;
-  inherit (lib.types) listOf package lines str path;
+  inherit (lib.types) listOf package lines str;
   inherit (lib.modules) mkIf mkRenamedOptionModule;
   inherit (lib.lists) optionals;
   inherit (lib.attrsets) optionalAttrs;
@@ -59,7 +59,7 @@ in {
       '';
     };
     gtk2Location = mkOption {
-      type = path;
+      type = str;
       default = ".gtkrc-2.0";
       defaultText = "$HOME/.gtkrc-2.0";
       example = ".config/gtk-2.0/gtkrc";


### PR DESCRIPTION
change gtk2Location's type to `str` so it can be a relative path, as intended.

### Meta

Related Issue(s): \<None\>

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
