### PR TITLE
modules/gtk: fix gtk-3.0/gtk-4.0 settings.ini path

### DIFF
--- a/modules/collection/misc/gtk.nix
+++ b/modules/collection/misc/gtk.nix
@@ -121,8 +121,8 @@ in {
     };
     xdg.config.files = (
       optionalAttrs (cfg.settings != {}) {
-        ".config/gtk-3.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
-        ".config/gtk-4.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
+        "gtk-3.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
+        "gtk-4.0/settings.ini".text = toGtkINI {Settings = cfg.settings;};
       }
       // optionalAttrs (cfg.css.gtk3 != "") {
         "gtk-3.0/gtk.css".text = cfg.css.gtk3;


### PR DESCRIPTION
I noticed that `settings.ini` was being created in `~/.config/.config/gtk-<ver>/settings.ini`  instead of just `~/.config/gtk-<ver>/settings.ini`

This PR should fix that problem.

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [ ] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
