### PR TITLE
programs/obs-studio: change package override example to working one

### DIFF
--- a/modules/collection/programs/obs-studio.nix
+++ b/modules/collection/programs/obs-studio.nix
@@ -19,7 +19,7 @@ in {
       '';
       example = ''
         # OBS has a special "package" to wrap the obs-studio package with plugins
-        package = pkgs.wrapOBS.override {
+        package = pkgs.wrapOBS.override { obs-studio = pkgs.obs-studio; } {
           # These plugins will get installed and wrapped into obs-studio for use
           plugins = with pkgs.obs-studio-plugins; [
             wlrobs


### PR DESCRIPTION


[This is a comment]: : 
The example provided in current description doesn't work, from my testing it outputs an error
`error: function 'anonymous lambda' called with unexpected argument 'plugins'`

So I just got the correct example from [home-manager module](https://github.com/nix-community/home-manager/blob/c0016dd14773f4ca0b467b74c7cdcc501570df4b/modules/programs/obs-studio.nix#L39)

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [ ] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
