### PR TITLE
programs/mpv: fix tests and rename test module

### DIFF
--- a/modules/tests/collection/programs/mpv.nix
+++ b/modules/tests/collection/programs/mpv.nix
@@ -1,5 +1,5 @@
 {
-  name = "mpv";
+  name = "programs-mpv";
   nodes.machine = {
     hjem.users.bob.rum = {
       programs.mpv = {


### PR DESCRIPTION
- `mpv`'s tests check for binding configuration at the wrong path.
- `mpv`'s tests name caught me by surprise. I renamed it to the expected name.

This looks like a miss from the init PR. @arthsmn, could you confirm? Idk about `mpv` so I'm not sure if this change is correct.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: Yes/No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
