### PR TITLE
programs/imv: init module

### DIFF
--- a/docs/manpage-urls.json
+++ b/docs/manpage-urls.json
@@ -2,5 +2,6 @@
   "fuzzel.ini(5)": "https://man.archlinux.org/man/fuzzel.ini.5",
   "tofi(5)": "https://github.com/philj56/tofi/blob/master/doc/tofi.5.md",
   "ncmpcpp(1)": "https://man.archlinux.org/man/ncmpcpp.1",
-  "foot.ini(5)": "https://man.archlinux.org/man/foot.ini.5.en"
+  "foot.ini(5)": "https://man.archlinux.org/man/foot.ini.5.en",
+  "IMV(5)": "https://man.archlinux.org/man/imv.5.en"
 }

--- a/modules/collection/programs/imv.nix
+++ b/modules/collection/programs/imv.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
+
+  ini = pkgs.formats.ini {};
+
+  cfg = config.rum.programs.imv;
+
+  optionsFile = ini.generate "imv-options.ini" {
+    options = cfg.settings.options or {};
+  };
+  aliasesFile = ini.generate "imv-aliases.ini" {
+    aliases = cfg.settings.aliases or {};
+  };
+  bindsFile = ini.generate "imv-binds.ini" {
+    binds = cfg.settings.binds or {};
+  };
+in {
+  options.rum.programs.imv = {
+    enable = mkEnableOption "imv";
+
+    package = mkPackageOption pkgs "imv" {nullable = true;};
+
+    settings = mkOption {
+      type = ini.type;
+      default = {};
+      example = {
+        options.background = "ffffff";
+        aliases.x = "close";
+      };
+      description = ''
+        Settings are written as an INI file to {file}`$XDG_CONFIG_HOME/imv/config`.
+        The lists are separated between options, aliases, and binds.
+        Please reference {manpage}`IMV(5)` to configure it accordingly.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    packages = mkIf (cfg.package != null) [cfg.package];
+    xdg.config.files."imv/config" = mkIf (cfg.settings != {}) {
+      source = pkgs.concatText "imv-config.ini" [
+        optionsFile
+        aliasesFile
+        bindsFile
+      ];
+    };
+  };
+}

--- a/modules/tests/collection/programs/imv/expected_config
+++ b/modules/tests/collection/programs/imv/expected_config
@@ -1,0 +1,9 @@
+[options]
+suppress_default_binds=true
+[aliases]
+[binds]
+<Ctrl+r>=rotate by 90
+<Shift+T>=slideshow -1
+<period>=next_frame
+<space>=toggle_playing
+t=slideshow +1

--- a/modules/tests/collection/programs/imv/imv.nix
+++ b/modules/tests/collection/programs/imv/imv.nix
@@ -1,0 +1,39 @@
+let
+  settings = {
+    options.suppress_default_binds = true;
+    binds = {
+      "<Ctrl+r>" = "rotate by 90";
+      "<period>" = "next_frame";
+      "<space>" = "toggle_playing";
+      "t" = "slideshow +1";
+      "<Shift+T>" = "slideshow -1";
+    };
+  };
+in {
+  name = "programs-imv";
+  nodes.machine = {
+    hjem.users.bob.rum = {
+      programs.imv = {
+        enable = true;
+        inherit settings;
+      };
+    };
+  };
+
+  testScript =
+    #python
+    ''
+      # Waiting for our user to load.
+      machine.succeed("loginctl enable-linger bob")
+      machine.wait_for_unit("default.target")
+
+      confPath = "/home/bob/.config/imv/config"
+
+      # Checks if the imv config file exists in the expected place.
+      machine.succeed("[ -r %s ]" % confPath)
+
+      # Assert that the generated config is applied correctly.
+      machine.copy_from_host("${./expected_config}", "/home/bob/expected_config")
+      machine.succeed("diff -u -Z -b -B %s /home/bob/expected_config" % confPath)
+    '';
+}


### PR DESCRIPTION
Add imv module to collection/programs, add tests, and add imv manual to docs.

The imv config file is tricky, in a way that makes it improbable to just formats.ini it. Because section of `options` ,`aliases`, `binds` have to be in this exact order. So if binds is above option's section, then binds wouldn't apply, and option would apply.

The downside currently is necessary boilerplate. If you have knowledge on how to improve the module, please do share.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [x] Followed the general API laid out in CONTRIBUTING.md
- [x] Wrote tests (or expressed a need for help on tests)
