### PR TITLE
desktops/hyprland: add hyprland-session systemd unit if uwsm isn't used

### DIFF
--- a/modules/collection/desktops/hyprland.nix
+++ b/modules/collection/desktops/hyprland.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs,
   osConfig,
   config,
   rumLib,
@@ -68,54 +69,76 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
-    xdg.config.files = let
-      check = {
-        plugins = cfg.plugins != [];
-        settings = cfg.settings != {};
-        variables = {
-          noUWSM = config.environment.sessionVariables != {} && !osConfig.programs.hyprland.withUWSM;
-          withUWSM = config.environment.sessionVariables != {} && osConfig.programs.hyprland.withUWSM;
-        };
-        extraConfig = cfg.extraConfig != "";
+  config = let
+    check = {
+      plugins = cfg.plugins != [];
+      settings = cfg.settings != {};
+      variables = {
+        noUWSM = config.environment.sessionVariables != {} && !osConfig.programs.hyprland.withUWSM;
+        withUWSM = config.environment.sessionVariables != {} && osConfig.programs.hyprland.withUWSM;
       };
-    in {
-      "hypr/hyprland.conf" = mkIf (check.plugins || check.settings || check.variables.noUWSM || check.extraConfig) {
-        text =
-          optionalString check.plugins (pluginsToHyprconf cfg.plugins cfg.importantPrefixes)
-          + optionalString check.settings (toHyprconf {
-            attrs = cfg.settings;
-            inherit (cfg) importantPrefixes;
-          })
-          + optionalString check.variables.noUWSM (toHyprconf {
-            attrs.env =
-              # https://wiki.hyprland.org/Configuring/Environment-variables/#xdg-specifications
-              [
-                "XDG_CURRENT_DESKTOP,Hyprland"
-                "XDG_SESSION_TYPE,wayland"
-                "XDG_SESSION_DESKTOP,Hyprland"
-              ]
-              ++ mapAttrsToList (key: value: "${key},${value}") config.environment.sessionVariables;
-          })
-          + optionalString check.extraConfig cfg.extraConfig;
+      extraConfig = cfg.extraConfig != "";
+    };
+
+    systemdSessionCommand = lib.concatStringsSep "; " [
+      "${pkgs.dbus}/bin/dbus-update-activation-environment --systemd --all"
+      "systemctl --user stop hyprland-session.service"
+      "systemctl --user start hyprland-session.service"
+    ];
+  in
+    mkIf cfg.enable {
+      xdg.config.files = {
+        "hypr/hyprland.conf" = mkIf (check.plugins || check.settings || check.variables.noUWSM || check.extraConfig) {
+          text =
+            optionalString check.plugins (pluginsToHyprconf cfg.plugins cfg.importantPrefixes)
+            + optionalString check.settings (toHyprconf {
+              attrs = cfg.settings;
+              inherit (cfg) importantPrefixes;
+            })
+            + optionalString check.variables.noUWSM (toHyprconf {
+              attrs.env =
+                # https://wiki.hyprland.org/Configuring/Environment-variables/#xdg-specifications
+                [
+                  "XDG_CURRENT_DESKTOP,Hyprland"
+                  "XDG_SESSION_TYPE,wayland"
+                  "XDG_SESSION_DESKTOP,Hyprland"
+                ]
+                ++ mapAttrsToList (key: value: "${key},${value}") config.environment.sessionVariables;
+            })
+            + optionalString (!osConfig.programs.hyprland.withUWSM) "exec-once = ${systemdSessionCommand}\n"
+            + optionalString check.extraConfig cfg.extraConfig;
+        };
+
+        /*
+        uwsm environment variables are advised to be separated
+        (see https://wiki.hyprland.org/Configuring/Environment-variables/)
+        */
+        "uwsm/env" = mkIf check.variables.withUWSM {text = toEnvExport config.environment.sessionVariables;};
+
+        "uwsm/env-hyprland" = let
+          /*
+          this is needed as we're using a predicate so we don't create an empty file
+          (improvements are welcome)
+          */
+          filteredVars =
+            filterKeysPrefixes ["HYPRLAND_" "AQ_"] config.environment.sessionVariables;
+        in
+          mkIf (check.variables.withUWSM && filteredVars != {})
+          {text = toEnvExport filteredVars;};
       };
 
       /*
-      uwsm environment variables are advised to be separated
-      (see https://wiki.hyprland.org/Configuring/Environment-variables/)
+      since this is what home-manager does as well it is advised to disable systemd
+      integration if the user is using uwsm
+      we can just check if withUWSM is true and just not create the service
+      (see https://wiki.hypr.land/Useful-Utilities/Systemd-start/#uwsm)
       */
-      "uwsm/env" = mkIf check.variables.withUWSM {text = toEnvExport config.environment.sessionVariables;};
-
-      "uwsm/env-hyprland" = let
-        /*
-        this is needed as we're using a predicate so we don't create an empty file
-        (improvements are welcome)
-        */
-        filteredVars =
-          filterKeysPrefixes ["HYPRLAND_" "AQ_"] config.environment.sessionVariables;
-      in
-        mkIf (check.variables.withUWSM && filteredVars != {})
-        {text = toEnvExport filteredVars;};
+      systemd.services.hyprland-session = mkIf (!osConfig.programs.hyprland.withUWSM) {
+        description = "Hyprland compositor session";
+        documentation = ["man:systemd.special(7)"];
+        bindsTo = ["graphical-session.target"];
+        wants = ["graphical-session-pre.target"];
+        after = ["graphical-session-pre.target"];
+      };
     };
-  };
 }


### PR DESCRIPTION
This change aims to add the `hyprland-session` systemd unit for people who run Hyprland without `uwsm`. It also exposes the environment variables to the systemd user.

One thing to note is that this execs 
```${pkgs.dbus}/bin/dbus-update-activation-environment --systemd --all```

which exposes all environment variables to dbus and the systemd user. It is one of the options that the official Hyprland wiki suggests here https://wiki.hypr.land/Nix/Hyprland-on-Home-Manager/#programs-dont-work-in-systemd-services-but-do-on-the-terminal if some programs are not working but we might want to cherry pick only needed environment variables.

I will most likely rewrite some things in this PR to match what the `home-manager` module does now so we can be explicit about the environment variables to expose + the necessary ones with additional configuration but I didn't want to go that far yet without first getting a sanity check in adding the `systemd` unit.

For the time being I'll keep `--all` for now so I can pin my flake to this PR since I want to make sure I keep my dark mode enabled on GTK apps

Also another note: my code editor automatically formatted using `nix fmt` so it ended up formatting a bunch of lines I didn't touch unfortunately so this PR is a larger than I had intended.

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): #82 

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
