### PR TITLE
programs/chawan: init module

### DIFF
--- a/modules/collection/programs/chawan.nix
+++ b/modules/collection/programs/chawan.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
+
+  toml = pkgs.formats.toml {};
+
+  cfg = config.rum.programs.chawan;
+in {
+  options.rum.programs.chawan = {
+    enable = mkEnableOption "chawan";
+
+    package = mkPackageOption pkgs "chawan" {nullable = true;};
+
+    settings = mkOption {
+      type = toml.type;
+      default = {};
+      example = {
+        buffer = {
+          images = true;
+          autofocus = true;
+        };
+        page."C-k" = "() => pager.load('ddg:')";
+      };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/chawan/config.toml`.
+        Please reference [chawan's documentation] for config options.
+
+        [chawan's documentation]: https://git.sr.ht/~bptato/chawan/tree/master/doc/config.md
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    packages = mkIf (cfg.package != null) [cfg.package];
+    xdg.config.files."chawan/config.toml" = mkIf (cfg.settings != {}) {
+      source = toml.generate "chawan-config.toml" cfg.settings;
+    };
+  };
+}

--- a/modules/tests/collection/programs/chawan/chawan.nix
+++ b/modules/tests/collection/programs/chawan/chawan.nix
@@ -1,0 +1,36 @@
+let
+  settings = {
+    buffer = {
+      images = true;
+      autofocus = true;
+    };
+    page."C-k" = "() => pager.load('ddg:')";
+  };
+in {
+  name = "programs-chawan";
+  nodes.machine = {
+    hjem.users.bob.rum = {
+      programs.chawan = {
+        enable = true;
+        inherit settings;
+      };
+    };
+  };
+
+  testScript =
+    #python
+    ''
+      # Waiting for our user to load.
+      machine.succeed("loginctl enable-linger bob")
+      machine.wait_for_unit("default.target")
+
+      confPath = "/home/bob/.config/chawan/config.toml"
+
+      # Checks if the chawan config file exists in the expected place.
+      machine.succeed("[ -r %s ]" % confPath)
+
+      # Assert that the generated config is applied correctly.
+      machine.copy_from_host("${./expected_config}", "/home/bob/expected_config")
+      machine.succeed("diff -u -Z -b -B %s /home/bob/expected_config" % confPath)
+    '';
+}

--- a/modules/tests/collection/programs/chawan/expected_config
+++ b/modules/tests/collection/programs/chawan/expected_config
@@ -1,0 +1,6 @@
+[buffer]
+autofocus = true
+images = true
+
+[page]
+C-k = "() => pager.load('ddg:')"


### PR DESCRIPTION
init module for chawan, added tests. Configured with toml values. Doesn't include configuration for the bookmark.md and history.uri files in the same `.config/chawan` folder.

project repository: https://git.sr.ht/~bptato/chawan

chawan is a TUI browser, can be executed with command `cha https://git.sr.ht/~bptato/chawan`

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [x] Followed the general API laid out in CONTRIBUTING.md
- [x] Wrote tests (or expressed a need for help on tests)
