### PR TITLE
desktops/i3: init module

### DIFF
--- a/modules/collection/desktops/i3.nix
+++ b/modules/collection/desktops/i3.nix
@@ -1,0 +1,177 @@
+{
+  config,
+  lib,
+  osConfig,
+  pkgs,
+  ...
+}: let
+  inherit (lib.attrsets) mapAttrs' nameValuePair;
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) literalExpression mkOption mkEnableOption mkPackageOption;
+  inherit (lib.strings) concatMapStringsSep concatStringsSep optionalString;
+  inherit (lib.types) attrsOf lines listOf path;
+
+  json = pkgs.formats.json {};
+
+  cfg = config.rum.desktops.i3;
+in {
+  options.rum.desktops.i3 = {
+    enable = mkEnableOption "i3";
+
+    package =
+      mkPackageOption pkgs "i3" {
+        nullable = true;
+        extraDescription = ''
+          Only used to validate the generated config file. Set to `null` to
+          disable the check phase.
+        '';
+      }
+      // {
+        # This is not above because mkPackageOption's implementation will evaluate `osConfig`, causing eval failures for documentation and checks.
+        default = osConfig.services.xserver.windowManager.i3.package;
+        defaultText = literalExpression "osConfig.services.xserver.windowManager.i3.package";
+      };
+
+    commands = mkOption {
+      type = lines;
+      default = "";
+      example = ''
+        # Launch on startup
+        exec --no-startup-id i3-msg 'workspace 1; exec ''${lib.getExe pkgs.firefox}'
+
+        # Key bindings - Workspaces
+        ''${lib.concatStrings (
+          map (n: '''
+            bindsym $mod+''${toString n} workspace number ''${if n == 0 then "10" else toString n}
+            bindsym $mod+Shift+''${toString n} move container to workspace number ''${
+              if n == 0 then "10" else toString n
+            }
+          ''') (builtins.genList (i: i) 10)
+        )}
+      '';
+      description = ''
+        Commands that will be run to configure i3 written to
+        {file}`$HOME/.config/i3/config`. Please reference [i3's documentation]
+        for possible commands.
+
+        [i3's documentation]: https://i3wm.org/docs/userguide.html#configuring
+      '';
+    };
+
+    includes = mkOption {
+      type = listOf path;
+      default = [];
+      example = literalExpression ''
+        [ ./assignments.conf ./''${hostname}.conf ]
+      '';
+      description = ''
+        A list of other files that will be included in the configuration file.
+        See [i3's docs] on the include directive for more information.
+
+        [i3's docs]: https://i3wm.org/docs/userguide.html#include
+      '';
+    };
+
+    layouts = mkOption {
+      type = attrsOf (listOf json.type);
+      default = {};
+      example = {
+        main = [
+          {
+            layout = "splitv";
+            percent = 0.4;
+            type = "con";
+            nodes = [
+              {
+                border = "none";
+                name = "irssi";
+                percent = 0.5;
+                type = "con";
+                swallows = [
+                  {
+                    class = "^URxvt$";
+                    instance = "^irssi$";
+                  }
+                ];
+              }
+              {
+                layout = "stacked";
+                percent = 0.5;
+                type = "con";
+                nodes = [
+                  {
+                    name = "notmuch";
+                    percent = 0.5;
+                    type = "con";
+                    swallows = [
+                      {
+                        class = "^Emacs$";
+                        instance = "^notmuch$";
+                      }
+                    ];
+                  }
+                  {
+                    name = "midna: -";
+                    percent = 0.5;
+                    type = "con";
+                  }
+                ];
+              }
+            ];
+          }
+          {
+            layout = "stacked";
+            percent = 0.6;
+            type = "con";
+            nodes = [
+              {
+                name = "chrome";
+                type = "con";
+                swallows = [
+                  {
+                    class = "^Google-chrome$";
+                  }
+                ];
+              }
+            ];
+          }
+        ];
+      };
+      description = ''
+        Workspace layouts written to {file}`$HOME/.config/i3/*.json`.
+        Read more about i3's layouts [here].
+
+        Setting this option doesn't automatically load the defined layouts
+        allowing users to load them in their preferred way. Reference i3's
+        documentation on [restoring the layout] for possible options.
+
+        [here]: https://i3wm.org/docs/layout-saving.html
+        [restoring the layout]: https://i3wm.org/docs/layout-saving.html#_restoring_the_layout
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    xdg.config.files =
+      {
+        "i3/config" = mkIf (cfg.commands != "") {
+          source = pkgs.writeTextFile {
+            name = "i3-config";
+            text = concatStringsSep "\n" [
+              (concatMapStringsSep "\n" (file: "include \"${file}\"") cfg.includes)
+              cfg.commands
+            ];
+            checkPhase = optionalString (cfg.package != null) ''
+              ${getExe cfg.package} -c "$target" -C -d all
+            '';
+          };
+        };
+      }
+      // (mapAttrs' (name: value:
+        nameValuePair "i3/${name}.json" {
+          source = json.generate "i3-${name}-layout.json" value;
+        })
+      cfg.layouts);
+  };
+}

--- a/modules/tests/collection/programs/i3.nix
+++ b/modules/tests/collection/programs/i3.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  pkgs,
+  ...
+}: {
+  name = "desktops-i3";
+  nodes.machine = {
+    hjem.users.bob.rum = {
+      desktops.i3 = {
+        enable = true;
+        commands = ''
+          # Launch on startup
+          exec --no-startup-id i3-msg 'workspace 1; exec ${lib.getExe pkgs.firefox}'
+
+          # Key bindings - Workspaces
+          ${lib.concatStrings (
+            map (n: ''
+              bindsym $mod+${toString n} workspace number ${
+                if n == 0
+                then "10"
+                else toString n
+              }
+              bindsym $mod+Shift+${toString n} move container to workspace number ${
+                if n == 0
+                then "10"
+                else toString n
+              }
+            '') (builtins.genList (i: i) 10)
+          )}
+        '';
+        layouts.main = [
+          {
+            layout = "stacked";
+            percent = 0.6;
+            type = "con";
+            nodes = [
+              {
+                name = "chrome";
+                type = "con";
+                swallows = [
+                  {
+                    class = "^Google-chrome$";
+                  }
+                ];
+              }
+            ];
+          }
+        ];
+      };
+    };
+  };
+
+  testScript = ''
+    # Waiting for our user to load.
+    machine.succeed("loginctl enable-linger bob")
+    machine.wait_for_unit("default.target")
+
+    # Assert that the i3 config is valid
+    machine.succeed("${lib.getExe pkgs.i3} -c %s -C -d all" % "/home/bob/.config/i3/config")
+
+    # Check if the main layout file exists in the expected place.
+    machine.succeed("[ -r %s ]" % "/home/bob/.config/i3/main.json")
+  '';
+}


### PR DESCRIPTION
This one took me a while and I still feel more can be done. I've listed them in the first comment.

Writing a module for this was a nightmare and I lost the battle trying to make `i3.commands` be a proper Nix type rather than just a multi-line string. It's either that or going down the HM route of defining submodule options for each command there is. A few things I wanted to note/discuss:
- I could do something similar to the `niri` module which only abstracts certain things like `binds`, `spawn-on-startup`, etc. Should I do this?
- About sourcing env vars (#17), from what I gathered, i3's config doesn't support this at all and instead relies on files like `.xsession`, `.xinitrc`, and friends to export env vars before i3 launches. Those should be different modules and I didn't research enough on them to confidently write a module. I also thought about using [`i3.extraSessionCommands`](https://github.com/NixOS/nixpkgs/blob/5ae3b07d8d6527c42f17c876e404993199144b6a/nixos/modules/services/x11/window-managers/i3.nix#L40-L46) from the nixpkgs nixos module to export env vars but idk if that's good practice or not. Need more folks to comment on this.

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): #17 (see above)

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No, but I yoinked some stuff from the `niri` module

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [x] Followed the general API laid out in CONTRIBUTING.md
- [x] Wrote tests (or expressed a need for help on tests)
