### PR TITLE
programs/dunst: init module

### DIFF
--- a/modules/collection/programs/dunst.nix
+++ b/modules/collection/programs/dunst.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkEnableOption mkOption mkPackageOption;
+
+  ini = pkgs.formats.ini {};
+
+  cfg = config.rum.programs.dunst;
+in {
+  options.rum.programs.dunst = {
+    enable = mkEnableOption "dunst";
+
+    package = mkPackageOption pkgs "dunst" {nullable = true;};
+
+    settings = mkOption {
+      type = ini.type;
+      default = {};
+      example = {
+        global = {
+          font = "Roboto Mono 8";
+          frame_width = 2;
+          offset = "(40,50)";
+          origin = "top-right";
+          separator_height = 2;
+          sort = true;
+          transparency = 0;
+          width = 300;
+        };
+        urgency_low = {
+          background = "\"#191919\"";
+          foreground = "\"#BBBBBB\"";
+        };
+        urgency_normal = {
+          background = "\"#191919\"";
+          foreground = "\"#BBBBBB\"";
+        };
+        urgency_critical = {
+          background = "\"#191919\"";
+          foreground = "\"#DE6E7C\"";
+        };
+      };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/.config/dunst/dunstrc`.
+        Please reference [dunst's documentation] for config options.
+
+        [dunst's documentation]: https://dunst-project.org/documentation
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    packages = mkIf (cfg.package != null) [cfg.package];
+    xdg.config.files."dunst/dunstrc" = mkIf (cfg.settings != {}) {
+      source = ini.generate "dunstrc" cfg.settings;
+    };
+  };
+}

--- a/modules/tests/collection/programs/dunst.nix
+++ b/modules/tests/collection/programs/dunst.nix
@@ -1,0 +1,52 @@
+{
+  name = "programs-dunst";
+  nodes.machine = {
+    hjem.users.bob.rum = {
+      programs.dunst = {
+        enable = true;
+        settings = {
+          global = {
+            font = "Roboto Mono 8";
+            frame_width = 2;
+            offset = "(40,50)";
+            origin = "top-right";
+            separator_height = 2;
+            sort = true;
+            transparency = 0;
+            width = 300;
+          };
+          urgency_low = {
+            background = "\"#191919\"";
+            foreground = "\"#BBBBBB\"";
+          };
+          urgency_normal = {
+            background = "\"#191919\"";
+            foreground = "\"#BBBBBB\"";
+          };
+          urgency_critical = {
+            background = "\"#191919\"";
+            foreground = "\"#DE6E7C\"";
+          };
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    # Waiting for our user to load.
+    machine.succeed("loginctl enable-linger bob")
+    machine.wait_for_unit("default.target")
+
+    confPath = "/home/bob/.config/dunst/dunstrc"
+
+    # Check if the dunst config file exists in the expected place.
+    machine.succeed("[ -r %s ]" % confPath)
+
+    # Validate the contents of the config file.
+    machine.fail("su bob -c 'dunst -config %s >/tmp/dunst.log 2>&1'" % confPath)
+    stdout = machine.succeed("cat /tmp/dunst.log")
+    logs, _ = stdout.split("WARNING: Cannot open X11 display.")
+    if "WARNING" in logs:
+      raise AssertionError(f"Unexpected WARNING in dunst logs:\n\n{logs}")
+  '';
+}


### PR DESCRIPTION
Adds [`dunst`](https://dunst-project.org/) module

Took me a while to write the validation tests for this. I'm not super happy with doing string parsing to figure out the errors. If this turns out to be error-prone (e.g. breaks with newer dunst, or on wayland when the VM tests move), and it's frequent, we should probably remove it.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [x] Followed the general API laid out in CONTRIBUTING.md
- [x] Wrote tests (or expressed a need for help on tests)
