### PR TITLE
treewide: make shell integrations default to true

### DIFF
--- a/modules/collection/programs/direnv.nix
+++ b/modules/collection/programs/direnv.nix
@@ -55,7 +55,12 @@ in {
     };
 
     integrations = {
-      fish.enable = mkEnableOption "direnv integration with fish";
+      fish.enable =
+        mkEnableOption "direnv integration with fish"
+        // {
+          default = true;
+          example = false;
+        };
       nix-direnv = {
         enable =
           mkEnableOption "direnv integration with nix-direnv"
@@ -65,8 +70,18 @@ in {
           };
         package = mkPackageOption pkgs "nix-direnv" {};
       };
-      nushell.enable = mkEnableOption "direnv integration with nushell";
-      zsh.enable = mkEnableOption "direnv integration with zsh";
+      nushell.enable =
+        mkEnableOption "direnv integration with nushell"
+        // {
+          default = true;
+          example = false;
+        };
+      zsh.enable =
+        mkEnableOption "direnv integration with zsh"
+        // {
+          default = true;
+          example = false;
+        };
     };
   };
 

--- a/modules/collection/programs/fzf.nix
+++ b/modules/collection/programs/fzf.nix
@@ -16,8 +16,18 @@ in {
     package = mkPackageOption pkgs "fzf" {nullable = true;};
 
     integrations = {
-      fish.enable = mkEnableOption "fzf integration with fish";
-      zsh.enable = mkEnableOption "fzf integration with zsh";
+      fish.enable =
+        mkEnableOption "fzf integration with fish"
+        // {
+          default = true;
+          example = false;
+        };
+      zsh.enable =
+        mkEnableOption "fzf integration with zsh"
+        // {
+          default = true;
+          example = false;
+        };
     };
   };
 

--- a/modules/collection/programs/kitty.nix
+++ b/modules/collection/programs/kitty.nix
@@ -79,8 +79,18 @@ in {
     };
 
     integrations = {
-      fish.enable = mkEnableOption "kitty integration with fish";
-      zsh.enable = mkEnableOption "kitty integration with zsh";
+      fish.enable =
+        mkEnableOption "kitty integration with fish"
+        // {
+          default = true;
+          example = false;
+        };
+      zsh.enable =
+        mkEnableOption "kitty integration with zsh"
+        // {
+          default = true;
+          example = false;
+        };
     };
   };
 
@@ -90,7 +100,7 @@ in {
       "kitty/kitty.conf" = mkIf (cfg.settings != {}) {
         source = kittyKeyValue.generate "kitty.conf" (
           cfg.settings
-          // optionalAttrs (cfg.integrations.fish.enable || cfg.integrations.zsh.enable) {shell_integration = "no-rc";}
+          // optionalAttrs ((cfg.integrations.fish.enable && config.rum.programs.fish.enable) || (cfg.integrations.zsh.enable && config.rum.programs.zsh.enable)) {shell_integration = "no-rc";}
         );
       };
       "kitty/light-theme.auto.conf" = mkIf (cfg.theme.light != null) {source = cfg.theme.light;};

--- a/modules/collection/programs/nix-your-shell.nix
+++ b/modules/collection/programs/nix-your-shell.nix
@@ -16,9 +16,24 @@ in {
     package = mkPackageOption pkgs "nix-your-shell" {nullable = true;};
 
     integrations = {
-      fish.enable = mkEnableOption "nix-your-shell integration with fish";
-      zsh.enable = mkEnableOption "nix-your-shell integration with zsh";
-      nushell.enable = mkEnableOption "nix-your-shell integration with nushell";
+      fish.enable =
+        mkEnableOption "nix-your-shell integration with fish"
+        // {
+          default = true;
+          example = false;
+        };
+      nushell.enable =
+        mkEnableOption "nix-your-shell integration with nushell"
+        // {
+          default = true;
+          example = false;
+        };
+      zsh.enable =
+        mkEnableOption "nix-your-shell integration with zsh"
+        // {
+          default = true;
+          example = false;
+        };
     };
   };
 

--- a/modules/collection/programs/starship.nix
+++ b/modules/collection/programs/starship.nix
@@ -45,9 +45,24 @@ in {
     transience.enable = mkEnableOption "enable transience";
 
     integrations = {
-      fish.enable = mkEnableOption "starship integration with fish";
-      nushell.enable = mkEnableOption "starship integration with nushell";
-      zsh.enable = mkEnableOption "starship integration with zsh";
+      fish.enable =
+        mkEnableOption "starship integration with fish"
+        // {
+          default = true;
+          example = false;
+        };
+      nushell.enable =
+        mkEnableOption "starship integration with nushell"
+        // {
+          default = true;
+          example = false;
+        };
+      zsh.enable =
+        mkEnableOption "starship integration with zsh"
+        // {
+          default = true;
+          example = false;
+        };
     };
   };
 

--- a/modules/collection/programs/zoxide.nix
+++ b/modules/collection/programs/zoxide.nix
@@ -34,9 +34,24 @@ in {
     };
 
     integrations = {
-      fish.enable = mkEnableOption "zoxide integration with fish";
-      zsh.enable = mkEnableOption "zoxide integration with zsh";
-      nushell.enable = mkEnableOption "zoxide integration with nushell";
+      fish.enable =
+        mkEnableOption "zoxide integration with fish"
+        // {
+          default = true;
+          example = false;
+        };
+      nushell.enable =
+        mkEnableOption "zoxide integration with nushell"
+        // {
+          default = true;
+          example = false;
+        };
+      zsh.enable =
+        mkEnableOption "zoxide integration with zsh"
+        // {
+          default = true;
+          example = false;
+        };
     };
   };
 

--- a/modules/tests/collection/programs/direnv/direnv.nix
+++ b/modules/tests/collection/programs/direnv/direnv.nix
@@ -18,10 +18,6 @@
           	)}"
           }
         '';
-        integrations.fish.enable = true;
-        integrations.nix-direnv.enable = true;
-        integrations.nushell.enable = true;
-        integrations.zsh.enable = true;
       };
       programs.fish.enable = true;
       programs.nushell.enable = true;

--- a/modules/tests/collection/programs/fzf.nix
+++ b/modules/tests/collection/programs/fzf.nix
@@ -2,11 +2,7 @@
   name = "programs-fzf";
   nodes.machine = {
     hjem.users.bob.rum = {
-      programs.fzf = {
-        enable = true;
-        integrations.fish.enable = true;
-        integrations.zsh.enable = true;
-      };
+      programs.fzf.enable = true;
       programs.fish.enable = true;
       programs.zsh.enable = true;
     };

--- a/modules/tests/collection/programs/kitty/kitty.nix
+++ b/modules/tests/collection/programs/kitty/kitty.nix
@@ -18,8 +18,6 @@
           dark = "${pkgs.kitty-themes}/share/kitty-themes/themes/1984_dark.conf";
           no-preference = "${pkgs.kitty-themes}/share/kitty-themes/themes/default.conf";
         };
-        integrations.fish.enable = true;
-        integrations.zsh.enable = true;
       };
       programs.fish.enable = true;
       programs.zsh.enable = true;

--- a/modules/tests/collection/programs/nix-your-shell.nix
+++ b/modules/tests/collection/programs/nix-your-shell.nix
@@ -2,12 +2,7 @@
   name = "programs-nix-your-shell";
   nodes.machine = {
     hjem.users.bob.rum = {
-      programs.nix-your-shell = {
-        enable = true;
-        integrations.fish.enable = true;
-        integrations.zsh.enable = true;
-        integrations.nushell.enable = true;
-      };
+      programs.nix-your-shell.enable = true;
       programs.fish.enable = true;
       programs.zsh.enable = true;
       programs.nushell.enable = true;

--- a/modules/tests/collection/programs/zoxide.nix
+++ b/modules/tests/collection/programs/zoxide.nix
@@ -5,9 +5,6 @@
       programs.zoxide = {
         enable = true;
         flags = ["--cmd cd"];
-        integrations.fish.enable = true;
-        integrations.zsh.enable = true;
-        integrations.nushell.enable = true;
       };
       programs.fish.enable = true;
       programs.zsh.enable = true;


### PR DESCRIPTION
Marking this as a draft for now since I'm exploring making this change with another change discussed a while back of introducing `mkIntegration`.

I've tested this patch with my local config after removing the manual `integrations.zsh.enable` from my nixos config and my `.zshrc` is unchanged as expected.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
