### PR TITLE
programs/fzf: add env option for configuration

### DIFF
--- a/modules/collection/programs/fzf.nix
+++ b/modules/collection/programs/fzf.nix
@@ -50,7 +50,7 @@ in {
       {
         assertion = !attrNamesHasPrefix "FZF_" cfg.env;
         message = ''
-          Each env variable in `rum.programs.fzf.env` is automatically prefixed with `FZF_`. Adding this prefix manually will cause it to be added twice, causing the actual env variable to not apply.
+          Each env variable in {option}`rum.programs.fzf.env` is automatically prefixed with `FZF_`. Adding this prefix manually will cause it to be added twice, causing the actual env variable to not apply.
         '';
       }
     ];

--- a/modules/collection/programs/fzf.nix
+++ b/modules/collection/programs/fzf.nix
@@ -2,11 +2,16 @@
   lib,
   pkgs,
   config,
+  hjem-lib,
+  rumLib,
   ...
 }: let
+  inherit (hjem-lib) envVarType;
+  inherit (lib.attrsets) mapAttrs' nameValuePair;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkAfter mkIf;
-  inherit (lib.options) mkEnableOption mkPackageOption;
+  inherit (lib.options) mkEnableOption mkOption mkPackageOption;
+  inherit (rumLib.attrsets) attrNamesHasPrefix;
 
   cfg = config.rum.programs.fzf;
 in {
@@ -15,6 +20,25 @@ in {
 
     package = mkPackageOption pkgs "fzf" {nullable = true;};
 
+    env = mkOption {
+      type = envVarType;
+      default = {};
+      example = {
+        DEFAULT_COMMAND = "fd --type f";
+        DEFAULT_OPTS = "--layout=reverse --inline-info";
+        CTRL_T_OPTS = ''
+          --walker-skip .git,node_modules,target
+          --preview 'bat -n --color=always {}'
+          --bind 'ctrl-/:change-preview-window(down|hidden|)'
+        '';
+      };
+      description = ''
+        Environment variables passed to fzf with its shell integration.
+
+        Please note that each variable will have `FZF_` prepended to it.
+      '';
+    };
+
     integrations = {
       fish.enable = mkEnableOption "fzf integration with fish";
       zsh.enable = mkEnableOption "fzf integration with zsh";
@@ -22,7 +46,18 @@ in {
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !attrNamesHasPrefix "FZF_" cfg.env;
+        message = ''
+          Each env variable in `rum.programs.fzf.env` is automatically prefixed with `FZF_`. Adding this prefix manually will cause it to be added twice, causing the actual env variable to not apply.
+        '';
+      }
+    ];
+
     packages = mkIf (cfg.package != null) [cfg.package];
+
+    environment.sessionVariables = mapAttrs' (n: v: nameValuePair "FZF_${n}" v) cfg.env;
 
     rum.programs.fish.config = mkIf cfg.integrations.fish.enable (
       mkAfter "${getExe cfg.package} --fish | source"


### PR DESCRIPTION
The current fzf module's purpose is only to integrate with fish and zsh. It has a way to configure it, which is mainly through CLI flags, but also through some environment variables. These env vars don't have any alternative method of configuration, so we're forced to rely on those.

Since this is the only way to configure fzf, I think it's a good idea to add that as part of the module itself instead of having the user set them outside of the module definition.

Please feel free to nit.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
