### PR TITLE
programs/mpv: fix ill-defined escape in example

### DIFF
--- a/modules/collection/programs/mpv.nix
+++ b/modules/collection/programs/mpv.nix
@@ -44,7 +44,7 @@ in {
       example = {
         autofit-larger = "100%x100%";
         hwdec = true;
-        osd-playing-msg = "File: $\{filename}";
+        osd-playing-msg = "File: \${filename}";
       };
     };
 


### PR DESCRIPTION
Currently throws warning on lix main.
No reason not to fix it.

### Meta

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [ ] Filled in all meta items
- [ ] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open