### PR TITLE
programs/atlauncher: init module

### DIFF
--- a/modules/collection/programs/atlauncher.nix
+++ b/modules/collection/programs/atlauncher.nix
@@ -1,0 +1,47 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkEnableOption mkOption mkPackageOption;
+
+  json = pkgs.formats.json {};
+
+  cfg = config.rum.programs.atlauncher;
+in {
+  options.rum.programs.atlauncher = {
+    enable = mkEnableOption "ATLauncher";
+
+    package = mkPackageOption pkgs "atlauncher" {nullable = true;};
+
+    settings = mkOption {
+      type = json.type;
+      default = {};
+      example = {
+        enableAnalytics = true;
+        enableConsole = false;
+        enableTrayMenu = false;
+        firstTimeRun = false;
+        keepLauncherOpen = false;
+        theme = "com.atlauncher.themes.Dark";
+      };
+      description = ''
+        Configuration written to {file}`$XDG_DATA_HOME/ATLauncher/configs/ATLauncher.json`.
+
+        As of writing, there aren't any docs for the available configuration options,
+        but [this file] is a good reference for configuration options and their types.
+
+        [this file]: https://github.com/ATLauncher/ATLauncher/blob/-/src/main/java/com/atlauncher/data/Settings.java
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    packages = mkIf (cfg.package != null) [cfg.package];
+    xdg.data.files."ATLauncher/configs/ATLauncher.json" = mkIf (cfg.settings != {}) {
+      source = json.generate "atlauncher-config.json" cfg.settings;
+    };
+  };
+}


### PR DESCRIPTION
Config module for [ATLauncher](https://github.com/ATLauncher/ATLauncher).

I've intentionally not written tests because the only thing I'd be testing is if the file's in the right place and if the json was generated correctly. That isn't much of a test really.

Instead, we should have some treewide tests that test every example nix attribute generating correctly for example. Or, one big test that enables everything just to make sure things eval and _run_ without failures (this might already exist).

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [x] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
