### PR TITLE
programs/git: enable lists as duplicate keys

### DIFF
--- a/modules/collection/programs/git.nix
+++ b/modules/collection/programs/git.nix
@@ -11,7 +11,7 @@
   inherit (lib.strings) concatStringsSep;
   inherit (lib.types) lines listOf str;
 
-  gitIni = pkgs.formats.gitIni {};
+  gitIni = pkgs.formats.gitIni {listsAsDuplicateKeys = true;};
   cfg = config.rum.programs.git;
 in {
   imports = [(mkRemovedOptionModule ["rum" "programs" "git" "destination"] "The default destination is now under `~/.config/git`")];

--- a/modules/collection/programs/git.nix
+++ b/modules/collection/programs/git.nix
@@ -108,8 +108,8 @@ in {
             })
         );
       };
-      "git/ignore" = mkIf (cfg.ignore != {}) {text = cfg.ignore;};
-      "git/attributes" = mkIf (cfg.attributes != {}) {text = cfg.attributes;};
+      "git/ignore" = mkIf (cfg.ignore != "") {text = cfg.ignore;};
+      "git/attributes" = mkIf (cfg.attributes != "") {text = cfg.attributes;};
     };
   };
 }

--- a/modules/tests/collection/programs/git/config.ini
+++ b/modules/tests/collection/programs/git/config.ini
@@ -1,3 +1,8 @@
+[credential]
+    helper = "libsecret"
+    helper = "cache --timeout 7200"
+    helper = "oauth"
+
 [diff]
     external = "/nix/store/difft --background light --display inline --ignore-comments"
     tool = "difftastic"

--- a/modules/tests/collection/programs/git/git.nix
+++ b/modules/tests/collection/programs/git/git.nix
@@ -12,6 +12,7 @@
           push.autoSetupRemote = true;
           rebase.autoStash = true;
           safe.directory = "/tmp";
+          credential.helper = ["libsecret" "cache --timeout 7200" "oauth"];
         };
         ignore = ''
           .direnv/


### PR DESCRIPTION
I wanted to configure credential helpers but found that I couldn't, because lists were previously rejected by the type of the settings option. I fixed it by enabling `listsAsDuplicateKeys` on the `gitIni` generator.

I also that  `cfg.attributes` and `cft.ignore` were always linked even if empty, since they are strings and not attrsets, so I threw in the quick fix for that as well.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
