### PR TITLE
flake: bump hjem and nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,19 @@
   "nodes": {
     "hjem": {
       "inputs": {
+        "nix-darwin": [
+          "nix-darwin"
+        ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "smfh": "smfh"
+        ]
       },
       "locked": {
-        "lastModified": 1756255328,
-        "narHash": "sha256-WJ70Dv+tJjIl7mMOqUgcdcz+RrujDRoeKptiU6oh1lI=",
+        "lastModified": 1777732535,
+        "narHash": "sha256-gaHRkPaGAAjc6D4sZ+/haEKMJGO79tu4ROBlyOjXuco=",
         "owner": "feel-co",
         "repo": "hjem",
-        "rev": "2426d6ad20e767895e936ed0c9563cc4e2b6c96f",
+        "rev": "ab977051adce0bf9f7c1032327e72f0febda6f7b",
         "type": "github"
       },
       "original": {
@@ -40,6 +42,26 @@
         "type": "github"
       }
     },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777780666,
+        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1766070988,
@@ -58,11 +80,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1754498491,
-        "narHash": "sha256-erbiH2agUTD0Z30xcVSFcDHzkRvkRXOQ3lb887bcVrs=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c2ae88e026f9525daf89587f3cbee584b92b6134",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {
@@ -76,68 +98,9 @@
       "inputs": {
         "hjem": "hjem",
         "ndg": "ndg",
+        "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs_2",
         "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "hjem",
-          "smfh",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1747622321,
-        "narHash": "sha256-W0dYIWgsUu6rvOJRtKLhKskkv0VhQhJYGNIq+gGUc8g=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "bd030fd9983f7fddf87be1c64aa3064c8afa24c4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "smfh": {
-      "inputs": {
-        "nixpkgs": [
-          "hjem",
-          "nixpkgs"
-        ],
-        "rust-overlay": "rust-overlay",
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1749906619,
-        "narHash": "sha256-/9Ww10kYopxfCNNnNDwENTubs7Wzqlw+O6PJAHNOYQw=",
-        "owner": "feel-co",
-        "repo": "smfh",
-        "rev": "39f5c06153f63100376bc607b1465850b6df77fd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "feel-co",
-        "repo": "smfh",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     },
     "treefmt-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,12 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -10,6 +16,7 @@
     hjem = {
       url = "github:feel-co/hjem";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nix-darwin.follows = "nix-darwin";
     };
 
     # Avoid overriding the Nixpkgs of NDG, or otherwise it will have to be rebuilt.
@@ -58,7 +65,7 @@
     };
     packages = forAllSystems (pkgs: {
       docs = pkgs.callPackage ./docs/package.nix {
-        inherit (ndg.packages.${pkgs.system}) ndg;
+        inherit (ndg.packages.${pkgs.stdenv.hostPlatform.system}) ndg;
         inherit rumLib inputs;
       };
     });
@@ -69,10 +76,10 @@
         default = pkgs.mkShell {
           packages = with pkgs; [
             pre-commit
-            python312Packages.commitizen
+            commitizen
           ];
           inputsFrom = [
-            treefmtEval.${pkgs.system}.config.build.devShell
+            treefmtEval.${pkgs.stdenv.hostPlatform.system}.config.build.devShell
           ];
           shellHook = ''
             pre-commit install --hook-type pre-commit --hook-type commit-msg --hook-type pre-push
@@ -92,6 +99,6 @@
     );
 
     # Provide the default formatter to invoke on 'nix fmt'.
-    formatter = forAllSystems (pkgs: treefmtEval.${pkgs.system}.config.build.wrapper);
+    formatter = forAllSystems (pkgs: treefmtEval.${pkgs.stdenv.hostPlatform.system}.config.build.wrapper);
   };
 }

--- a/modules/collection/programs/beets.nix
+++ b/modules/collection/programs/beets.nix
@@ -14,7 +14,7 @@ in {
   options.rum.programs.beets = {
     enable = mkEnableOption "beets";
 
-    package = mkPackageOption pkgs "beets" {
+    package = mkPackageOption pkgs.python3Packages "beets" {
       nullable = true;
       extraDescription = ''
         To get plugins to work, you will need to override the beets derivation

--- a/modules/tests/collection/programs/beets/beets.nix
+++ b/modules/tests/collection/programs/beets/beets.nix
@@ -11,7 +11,7 @@ in {
     hjem.users.bob.rum = {
       programs.beets = {
         enable = true;
-        package = pkgs.beets.override {pluginOverrides.duplicates.enable = true;};
+        package = pkgs.python3Packages.beets.override {pluginOverrides.duplicates.enable = true;};
         inherit settings;
       };
     };


### PR DESCRIPTION
- Add nix-darwin as an input for downstream users, whose hjem input follows ours, to be able to override hjem's nix-darwin input
- Move commitizen out of the python3Packages package set
- Move beets into the python3Packages package set as the application doesn't seem to have overridable plugins
- Rename pkgs.system to pkgs.stdenv.hostPlatform.system

### Meta

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
