### PR TITLE
treewide: make generated config naming consistent

### DIFF
--- a/modules/collection/programs/alacritty.nix
+++ b/modules/collection/programs/alacritty.nix
@@ -46,7 +46,7 @@ in {
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files."alacritty/alacritty.toml" = mkIf (cfg.settings != {}) {
-      source = toml.generate "alacritty.toml" cfg.settings;
+      source = toml.generate "alacritty-alacritty.toml" cfg.settings;
     };
   };
 }

--- a/modules/collection/programs/beets.nix
+++ b/modules/collection/programs/beets.nix
@@ -70,7 +70,7 @@ in {
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files."beets/config.yaml" = mkIf (cfg.settings != {}) {
-      source = yaml.generate "config.yaml" cfg.settings;
+      source = yaml.generate "beets-config.yaml" cfg.settings;
     };
   };
 }

--- a/modules/collection/programs/bottom.nix
+++ b/modules/collection/programs/bottom.nix
@@ -41,7 +41,7 @@ in {
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files."bottom/bottom.toml" = mkIf (cfg.settings != {}) {
-      source = toml.generate "bottom.toml" cfg.settings;
+      source = toml.generate "bottom-bottom.toml" cfg.settings;
     };
   };
 }

--- a/modules/collection/programs/direnv.nix
+++ b/modules/collection/programs/direnv.nix
@@ -74,7 +74,7 @@ in {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files = {
       "direnv/direnv.toml" = mkIf (cfg.settings != {}) {
-        source = toml.generate "direnv-config.toml" cfg.settings;
+        source = toml.generate "direnv-direnv.toml" cfg.settings;
       };
       "direnv/direnvrc" = mkIf (cfg.direnvrc != "") {text = cfg.direnvrc;};
       "direnv/lib/nix-direnv.sh" = mkIf cfg.integrations.nix-direnv.enable {source = "${cfg.integrations.nix-direnv.package}/share/nix-direnv/direnvrc";};

--- a/modules/collection/programs/flameshot.nix
+++ b/modules/collection/programs/flameshot.nix
@@ -39,7 +39,7 @@ in {
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files."flameshot/flameshot.ini" = mkIf (cfg.settings != {}) {
-      source = ini.generate "flameshot.ini" cfg.settings;
+      source = ini.generate "flameshot-flameshot.ini" cfg.settings;
     };
   };
 }

--- a/modules/collection/programs/foot.nix
+++ b/modules/collection/programs/foot.nix
@@ -53,7 +53,7 @@ in {
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files."foot/foot.ini" = mkIf (cfg.settings != {}) {
-      source = ini.generate "foot.ini" cfg.settings;
+      source = ini.generate "foot-foot.ini" cfg.settings;
     };
   };
 }

--- a/modules/collection/programs/fuzzel.nix
+++ b/modules/collection/programs/fuzzel.nix
@@ -37,7 +37,7 @@ in {
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files."fuzzel/fuzzel.ini" = mkIf (cfg.settings != {}) {
-      source = ini.generate "fuzzel.ini" cfg.settings;
+      source = ini.generate "fuzzel-fuzzel.ini" cfg.settings;
     };
   };
 }

--- a/modules/collection/programs/ghostty.nix
+++ b/modules/collection/programs/ghostty.nix
@@ -23,7 +23,7 @@
       nameValuePair
       "ghostty/themes/${name}"
       {
-        source = keyValue.generate "ghostty-${name}-theme" value;
+        source = keyValue.generate "ghostty-themes-${name}" value;
       })
     themes;
 

--- a/modules/collection/programs/git.nix
+++ b/modules/collection/programs/git.nix
@@ -96,7 +96,7 @@ in {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files = {
       "git/config" = mkIf (cfg.settings != {} || cfg.integrations.difftastic.enable) {
-        source = gitIni.generate "config" (
+        source = gitIni.generate "git-config" (
           cfg.settings
           // (let
             difft-command = concatStringsSep " " ([(getExe cfg.integrations.difftastic.package)] ++ cfg.integrations.difftastic.flags);

--- a/modules/collection/programs/helix.nix
+++ b/modules/collection/programs/helix.nix
@@ -15,7 +15,7 @@
     mapAttrs' (
       name: value:
         nameValuePair "helix/themes/${name}.toml" {
-          source = toml.generate "helix-theme-${name}.toml" value;
+          source = toml.generate "helix-themes-${name}.toml" value;
         }
     )
     themes;

--- a/modules/collection/programs/imv.nix
+++ b/modules/collection/programs/imv.nix
@@ -44,7 +44,7 @@ in {
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files."imv/config" = mkIf (cfg.settings != {}) {
-      source = pkgs.concatText "imv-config.ini" [
+      source = pkgs.concatText "imv-config" [
         optionsFile
         aliasesFile
         bindsFile

--- a/modules/collection/programs/keepassxc.nix
+++ b/modules/collection/programs/keepassxc.nix
@@ -47,7 +47,7 @@ in {
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files."keepassxc/keepassxc.ini" = mkIf (cfg.settings != {}) {
-      source = ini.generate "keepassxc.ini" cfg.settings;
+      source = ini.generate "keepassxc-keepassxc.ini" cfg.settings;
     };
   };
 }

--- a/modules/collection/programs/kitty.nix
+++ b/modules/collection/programs/kitty.nix
@@ -88,7 +88,7 @@ in {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files = {
       "kitty/kitty.conf" = mkIf (cfg.settings != {}) {
-        source = kittyKeyValue.generate "kitty.conf" (
+        source = kittyKeyValue.generate "kitty-kitty.conf" (
           cfg.settings
           // optionalAttrs (cfg.integrations.fish.enable || cfg.integrations.zsh.enable) {shell_integration = "no-rc";}
         );

--- a/modules/collection/programs/lsd.nix
+++ b/modules/collection/programs/lsd.nix
@@ -74,13 +74,13 @@ in {
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files."lsd/config.yaml" = mkIf (cfg.settings != {}) {
-      source = yaml.generate "config.yaml" cfg.settings;
+      source = yaml.generate "lsd-config.yaml" cfg.settings;
     };
     xdg.config.files."lsd/icons.yaml" = mkIf (cfg.icons != {}) {
-      source = yaml.generate "icons.yaml" cfg.icons;
+      source = yaml.generate "lsd-icons.yaml" cfg.icons;
     };
     xdg.config.files."lsd/colors.yaml" = mkIf (cfg.colors != {}) {
-      source = yaml.generate "colors.yaml" cfg.colors;
+      source = yaml.generate "lsd-colors.yaml" cfg.colors;
     };
   };
 }

--- a/modules/collection/programs/spotify-player.nix
+++ b/modules/collection/programs/spotify-player.nix
@@ -144,16 +144,16 @@ in {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files = {
       "spotify-player/app.toml" = mkIf (cfg.settings != {}) {
-        source = toml.generate "spotify-player/app.toml" cfg.settings;
+        source = toml.generate "spotify-player-app.toml" cfg.settings;
       };
 
       # Passes each declared theme under the "themes" attr as needed
       "spotify-player/theme.toml" = mkIf (cfg.themes != []) {
-        source = toml.generate "spotify-player/theme.toml" {inherit (cfg) themes;};
+        source = toml.generate "spotify-player-theme.toml" {inherit (cfg) themes;};
       };
 
       "spotify-player/keymap.toml" = mkIf (cfg.keymap != {}) {
-        source = toml.generate "spotify-player/keymap.toml" cfg.keymap;
+        source = toml.generate "spotify-player-keymap.toml" cfg.keymap;
       };
     };
   };

--- a/modules/collection/programs/vscode.nix
+++ b/modules/collection/programs/vscode.nix
@@ -41,7 +41,7 @@ in {
     packages = mkIf (cfg.package != null) [cfg.package];
     xdg.config.files = {
       "Code/User/settings.json" = mkIf (cfg.settings != {}) {
-        source = json.generate "settings.json" cfg.settings;
+        source = json.generate "Code-User-settings.json" cfg.settings;
       };
     };
   };

--- a/modules/collection/programs/yazi.nix
+++ b/modules/collection/programs/yazi.nix
@@ -75,13 +75,13 @@ in {
 
     xdg.config.files = {
       "yazi/yazi.toml" = mkIf (cfg.settings != {}) {
-        source = toml.generate "yazi-config.toml" cfg.settings;
+        source = toml.generate "yazi-yazi.toml" cfg.settings;
       };
       "yazi/keymap.toml" = mkIf (cfg.keymap != {}) {
-        source = toml.generate "yazi-keymap-config.toml" cfg.keymap;
+        source = toml.generate "yazi-keymap.toml" cfg.keymap;
       };
       "yazi/theme.toml" = mkIf (cfg.theme != {}) {
-        source = toml.generate "yazi-theme-config.toml" cfg.theme;
+        source = toml.generate "yazi-theme.toml" cfg.theme;
       };
     };
   };

--- a/modules/collection/programs/zed.nix
+++ b/modules/collection/programs/zed.nix
@@ -181,12 +181,12 @@ in {
       }
       // (mapAttrs' (name: value:
         nameValuePair "zed/snippets/${name}.json" {
-          source = json.generate "zed-${name}-snippet.json" value;
+          source = json.generate "zed-snippets-${name}.json" value;
         })
       cfg.snippets)
       // (mapAttrs' (name: value:
         nameValuePair "zed/themes/${name}.json" {
-          source = json.generate "zed-${name}-theme.json" value;
+          source = json.generate "zed-themes-${name}.json" value;
         })
       cfg.themes);
   };


### PR DESCRIPTION
I noticed that my Git config in the nix store was:
```
/nix/store/iydisy58v7mjh7k486blsc4a1ngzn964-config
```

Which tells me nothing about what can I expect in that file just by the name. Other files, generated by `hjem`'s `text` option have naming based on the path in `xdg.config.files.${path}` with forward slashes replaced with hyphens.

This PR replicates that behaviour when manually setting the name of the generated file.

### Meta

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
