### PR TITLE
docs: update hjem user prefix

### DIFF
--- a/docs/package.nix
+++ b/docs/package.nix
@@ -79,8 +79,8 @@
       transformOptions = opt:
         opt
         // {
-          # This is needed, as otherwise, every option will be prefixed with `<name>.rum`
-          name = removePrefixes ["<name>."] opt.name;
+          # This is needed, as otherwise, every option will be prefixed with `<username>.rum`
+          name = removePrefixes ["<username>."] opt.name;
 
           declarations =
             map (


### PR DESCRIPTION
At some point Hjem updated the attribute name of users. This reflects that change in our module docs.

| Before | After |
| ---------------------- | ---------------------- |
| <img width="289" height="263" alt="image" src="https://github.com/user-attachments/assets/8b1ab96f-7cf0-4e65-b9fa-b4b62d398fd4" /> | <img width="289" height="263" alt="image" src="https://github.com/user-attachments/assets/f41bf474-268c-45dc-9568-cb188ceeab7a" /> |

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
