### PR TITLE
fix/ncmpcppBindingType.nix: failing to evaluate

### DIFF
--- a/modules/lib/types/ncmpcppBindingType.nix
+++ b/modules/lib/types/ncmpcppBindingType.nix
@@ -14,9 +14,9 @@ in (
         example = "p";
         apply = x:
           assert assertMsg (!isNull x) ''
-              A binding for ncmpcpp wasn't properly defined, as it's missing the key or command its binded to.
-              You need to specify a key or a command which'll run the specified actions.
-            ''; x;
+            A binding for ncmpcpp wasn't properly defined, as it's missing the key or command its binded to.
+            You need to specify a key or a command which'll run the specified actions.
+          ''; x;
       };
       actions = mkOption {
         type = nullOr (listOf str);

--- a/modules/lib/types/ncmpcppBindingType.nix
+++ b/modules/lib/types/ncmpcppBindingType.nix
@@ -13,7 +13,7 @@ in (
         example = "p";
         apply = x:
           assert (!isNull x
-            || ''
+            || throw ''
               A binding for ncmpcpp wasn't properly defined, as it's missing the key or command its binded to.
               You need to specify a key or a command which'll run the specified actions.
             ''); x;

--- a/modules/lib/types/ncmpcppBindingType.nix
+++ b/modules/lib/types/ncmpcppBindingType.nix
@@ -1,6 +1,7 @@
 {lib}: let
   inherit (lib.types) nullOr listOf bool str submodule;
   inherit (lib.options) mkOption;
+  inherit (lib.asserts) assertMsg;
 in (
   submodule {
     options = {
@@ -12,11 +13,10 @@ in (
         '';
         example = "p";
         apply = x:
-          assert (!isNull x
-            || throw ''
+          assert assertMsg (!isNull x) ''
               A binding for ncmpcpp wasn't properly defined, as it's missing the key or command its binded to.
               You need to specify a key or a command which'll run the specified actions.
-            ''); x;
+            ''; x;
       };
       actions = mkOption {
         type = nullOr (listOf str);


### PR DESCRIPTION
This PR fixes an issue (invalid syntax used) that makes hjem-rum fail to evaluate under certain conditions.
Worth mentioning that I myself do not use `hjem-rum`, [rysieko](<https://github.com/rysieko>) has mentioned having an issue which I helped fixing using a quick patch, and decided it's worth PR-ing it.

### Meta

Related Issue(s): None

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open