### PR TITLE
programs/zoxide: fix nullable package check

### DIFF
--- a/modules/collection/programs/zoxide.nix
+++ b/modules/collection/programs/zoxide.nix
@@ -41,7 +41,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    packages = mkIf (cfg.package != true) [cfg.package];
+    packages = mkIf (cfg.package != null) [cfg.package];
 
     rum.programs.fish.config = mkIf cfg.integrations.fish.enable (
       mkAfter "${getExe cfg.package} init fish ${toFlags} | source"


### PR DESCRIPTION
Fix the nullable package check to compare against `null` rather than `true`.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [X] Filled in all meta items
- [X] Mentioned any blockers before the PR can merge
- [X] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
