### PR TITLE
programs/gammastep: tests, configurable hooks, and systemd integration

### DIFF
--- a/docs/manpage-urls.json
+++ b/docs/manpage-urls.json
@@ -1,5 +1,6 @@
 {
   "fuzzel.ini(5)": "https://man.archlinux.org/man/fuzzel.ini.5",
+  "gammastep(1)": "https://man.archlinux.org/man/gammastep.1.en",
   "tofi(5)": "https://github.com/philj56/tofi/blob/master/doc/tofi.5.md",
   "ncmpcpp(1)": "https://man.archlinux.org/man/ncmpcpp.1",
   "foot.ini(5)": "https://man.archlinux.org/man/foot.ini.5.en",

--- a/modules/collection/programs/gammastep.nix
+++ b/modules/collection/programs/gammastep.nix
@@ -32,9 +32,10 @@ in {
       };
       description = ''
         Settings are written as an INI file to {file}`$XDG_CONFIG_HOME/gammastep/config.ini`.
-        Refer to [gammastep's example configuration] all available options.
+        Refer to {manpage}`gammastep(1)` for more information. Its [example configuration]
+        may also be useful.
 
-        [gammastep's example configuration]: https://gitlab.com/chinstrap/gammastep/-/blob/master/gammastep.conf.sample
+        [example configuration]: https://gitlab.com/chinstrap/gammastep/-/blob/master/gammastep.conf.sample
       '';
     };
   };

--- a/modules/collection/programs/gammastep.nix
+++ b/modules/collection/programs/gammastep.nix
@@ -5,7 +5,8 @@
   ...
 }: let
   inherit (lib.attrsets) mapAttrs' nameValuePair;
-  inherit (lib.modules) mkIf;
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) literalExpression mkOption mkEnableOption mkPackageOption;
   inherit (lib.types) attrsOf path;
 
@@ -64,18 +65,41 @@ in {
         If using a Nix path, make sure that gammastep can e[x]ecute the file.
       '';
     };
+
+    integrations.systemd.enable =
+      (mkEnableOption "gammastep integration with systemd")
+      // {
+        default = true;
+        defaultText = literalExpression "config.systemd.enable";
+        example = false;
+      };
   };
 
-  config = mkIf cfg.enable {
-    packages = mkIf (cfg.package != null) [cfg.package];
-    xdg.config.files =
-      {
-        "gammastep/config.ini" = mkIf (cfg.settings != {}) {
-          source = ini.generate "gammastep-config.ini" cfg.settings;
+  config = mkIf cfg.enable (mkMerge [
+    {
+      packages = mkIf (cfg.package != null) [cfg.package];
+      xdg.config.files =
+        {
+          "gammastep/config.ini" = mkIf (cfg.settings != {}) {
+            source = ini.generate "gammastep-config.ini" cfg.settings;
+          };
+        }
+        // mapAttrs' (name: script:
+          nameValuePair "gammastep/hooks/${name}" {source = script;})
+        cfg.hooks;
+    }
+    (mkIf cfg.integrations.systemd.enable {
+      systemd.services.gammastep = {
+        after = ["graphical-session.target"];
+        description = "Screen color temperature manager";
+        documentation = ["man:gammastep(1)" "https://gitlab.com/chinstrap/gammastep"];
+        partOf = ["graphical-session.target"];
+        serviceConfig = {
+          ExecStart = getExe cfg.package;
+          Restart = "on-failure";
         };
-      }
-      // mapAttrs' (name: script:
-        nameValuePair "gammastep/hooks/${name}" {source = script;})
-      cfg.hooks;
-  };
+        wantedBy = ["graphical-session.target"];
+      };
+    })
+  ]);
 }

--- a/modules/collection/programs/gammastep.nix
+++ b/modules/collection/programs/gammastep.nix
@@ -4,8 +4,10 @@
   pkgs,
   ...
 }: let
+  inherit (lib.attrsets) mapAttrs' nameValuePair;
   inherit (lib.modules) mkIf;
-  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
+  inherit (lib.options) literalExpression mkOption mkEnableOption mkPackageOption;
+  inherit (lib.types) attrsOf path;
 
   ini = pkgs.formats.ini {};
 
@@ -38,12 +40,42 @@ in {
         [example configuration]: https://gitlab.com/chinstrap/gammastep/-/blob/master/gammastep.conf.sample
       '';
     };
+
+    hooks = mkOption {
+      type = attrsOf path;
+      default = {};
+      example = literalExpression ''
+        {
+          echo-period = ./echo-period;
+          notify-period = pkgs.writeShellScript "notify-period" '''
+            case $1 in
+              period-changed)
+                exec ''${lib.getExe pkgs.libnotify} "gammastep" "Period changed from $2 to $3";;
+            esac
+          ''';
+        }
+      '';
+      description = ''
+        Executable hooks written to {file}`$XDG_CONFIG_HOME/gammastep/hooks/*`.
+        Refer to {manpage}`gammastep(1)` for more information.
+
+        Use any writer you like, such as {command}`pkgs.writeShellScript` or
+        {command}`pkgs.writers.writePython3`, to build the script.
+        If using a Nix path, make sure that gammastep can e[x]ecute the file.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    xdg.config.files."gammastep/config.ini" = mkIf (cfg.settings != {}) {
-      source = ini.generate "gammastep-config.ini" cfg.settings;
-    };
+    xdg.config.files =
+      {
+        "gammastep/config.ini" = mkIf (cfg.settings != {}) {
+          source = ini.generate "gammastep-config.ini" cfg.settings;
+        };
+      }
+      // mapAttrs' (name: script:
+        nameValuePair "gammastep/hooks/${name}" {source = script;})
+      cfg.hooks;
   };
 }

--- a/modules/tests/collection/programs/gammastep.nix
+++ b/modules/tests/collection/programs/gammastep.nix
@@ -81,5 +81,8 @@
         assert old in ("daytime", "night", "transition") and new == "none", (
             "Unexpected shutdown event: %r" % shutdown
         )
+
+    with subtest("Verify if gammastep.service is enabled"):
+        machine.succeed("su bob -c 'XDG_RUNTIME_DIR=/run/user/$(id -u bob) systemctl --user is-enabled gammastep.service'")
   '';
 }

--- a/modules/tests/collection/programs/gammastep.nix
+++ b/modules/tests/collection/programs/gammastep.nix
@@ -1,4 +1,4 @@
-{
+{pkgs, ...}: {
   name = "programs-gammastep";
   nodes.machine = {
     hjem.users.bob.rum = {
@@ -23,6 +23,15 @@
             lon = "12.6";
           };
         };
+
+        hooks = {
+          record-period = pkgs.writeShellScript "record-period" ''
+            case $1 in
+              period-changed)
+                echo "$2 -> $3" >> "$HOME/gammastep-period";;
+            esac
+          '';
+        };
       };
     };
   };
@@ -35,9 +44,13 @@
     with subtest("Verify if gammastep is in $PATH"):
         machine.succeed("su bob -c 'which gammastep'")
 
-    with subtest("Verify if the config file is in place"):
+    with subtest("Verify if the config files are in place"):
         confPath = "/home/bob/.config/gammastep/config.ini"
         machine.succeed("[ -r %s ]" % confPath)
+
+        hookPath = "/home/bob/.config/gammastep/hooks/record-period"
+        machine.succeed("[ -r %s ]" % hookPath)
+        machine.succeed("test -x %s" % hookPath)
 
     with subtest("Verify if gammastep is able to correctly read our config"):
         stdout = machine.succeed("su bob -c 'gammastep -vp' 2>&1")
@@ -54,5 +67,19 @@
                 "Expected line not found in gammastep output: %r\n"
                 "Full output was:\n%s" % (line, stdout)
             )
+
+    with subtest("Verify if gammastep is able to correctly exec our hook"):
+        machine.succeed("su bob -c 'timeout 5 gammastep -m dummy -v || true'")
+        machine.wait_for_file("/home/bob/gammastep-period")
+        startup, shutdown = machine.succeed("cat /home/bob/gammastep-period").strip().splitlines()
+
+        old, _, new = startup.partition(" -> ")
+        assert old == "none" and new in ("daytime", "night", "transition"), (
+            "Unexpected startup event: %r" % startup
+        )
+        old, _, new = shutdown.partition(" -> ")
+        assert old in ("daytime", "night", "transition") and new == "none", (
+            "Unexpected shutdown event: %r" % shutdown
+        )
   '';
 }

--- a/modules/tests/collection/programs/gammastep.nix
+++ b/modules/tests/collection/programs/gammastep.nix
@@ -1,0 +1,58 @@
+{
+  name = "programs-gammastep";
+  nodes.machine = {
+    hjem.users.bob.rum = {
+      programs.gammastep = {
+        enable = true;
+        settings = {
+          general = {
+            temp-day = 5700;
+            temp-night = 3600;
+            brightness-day = "0.9";
+            brightness-night = "0.7";
+            gamma-day = "0.8:0.7:0.6";
+            gamma-night = "0.5";
+            elevation-high = 5;
+            elevation-low = -3;
+            adjustment-method = "randr";
+            location-provider = "manual";
+          };
+
+          manual = {
+            lat = "55.7";
+            lon = "12.6";
+          };
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    # Waiting for our user to load.
+    machine.succeed("loginctl enable-linger bob")
+    machine.wait_for_unit("default.target")
+
+    with subtest("Verify if gammastep is in $PATH"):
+        machine.succeed("su bob -c 'which gammastep'")
+
+    with subtest("Verify if the config file is in place"):
+        confPath = "/home/bob/.config/gammastep/config.ini"
+        machine.succeed("[ -r %s ]" % confPath)
+
+    with subtest("Verify if gammastep is able to correctly read our config"):
+        stdout = machine.succeed("su bob -c 'gammastep -vp' 2>&1")
+        expected_lines = [
+            "Notice: Solar elevations: > 5.0 (Day), < -3.0 (Night)",
+            "Notice: Temperatures: 5700K (Day), 3600K (Night)",
+            "Notice: Brightness: 0.90:0.70",
+            "Notice: Gamma (Day): 0.800, 0.700, 0.600",
+            "Notice: Gamma (Night): 0.500, 0.500, 0.500",
+            "Notice: Location: 55.70 N, 12.60 E",
+        ]
+        for line in expected_lines:
+            assert line in stdout, (
+                "Expected line not found in gammastep output: %r\n"
+                "Full output was:\n%s" % (line, stdout)
+            )
+  '';
+}


### PR DESCRIPTION
Adds:
- Somewhat hacky tests to check if `gammastep` correctly reports back our configuration
- Configuration of hooks. These could've been of type `lines`, but given you need shebangs, I thought to make it of type `package` expecting consumers to use writers.
- Put down a systemd unit (supersedes #148). The test for this is a simple `is-enabled`; I'm open to ideas on what more we can do.

cc. @arthsmn (author of the module), would you be able to review/test these changes?

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: Yes (to dig into `gammastep` internals on how hooks are invoked to then test them)

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [x] Followed the general API laid out in CONTRIBUTING.md
- [x] Wrote tests (or expressed a need for help on tests)
