### PR TITLE
programs/beets: misc cleanup

### DIFF
--- a/modules/collection/programs/beets.nix
+++ b/modules/collection/programs/beets.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.options) mkOption mkEnableOption mkPackageOption literalExample;
+  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
 
   yaml = pkgs.formats.yaml {};
 
@@ -24,7 +24,7 @@ in {
         [beets derivation]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/audio/beets/builtin-plugins.nix
       '';
       example = ''
-        pkgs.beets.override {
+        pkgs.python3Packages.beets.override {
             pluginOverrides = {
                 fish.enable = true;
                 convert.enable = true;
@@ -41,7 +41,7 @@ in {
         Refer to the beets [documentation] for available options.
 
         If you would like to use plugins, please consult the description of
-        [rum.programs.beets.package](#option-rum-programs-beets-package) and the
+        {option}`rum.programs.beets.package` and the
         [official plugin documentation] on the plugins configuration.
 
         [documentation]: https://beets.readthedocs.io/en/stable/reference/config.html

--- a/modules/tests/collection/programs/beets/beets.nix
+++ b/modules/tests/collection/programs/beets/beets.nix
@@ -31,7 +31,7 @@ in {
           stdout = machine.succeed("su bob -c 'which beet'")
 
       with subtest("Verify that beets is aware of the config file"):
-          stdout = machine.succeed("su bob -c 'beet config -p'")
+          stdout = machine.succeed("su bob -c 'beet config --paths'")
           assert stdout == "%s\n" % confPath, "beets did not pick up on the config location"
 
       with subtest("Verify that the linked file contains the proper data"):


### PR DESCRIPTION
- Correct package override example
- Use {option} syntax instead of manual hyperlinking
- Use explicit `--paths` flag in tests
