### PR TITLE
programs/gammastep: fix non-systemd configurations not evaluating

### DIFF
--- a/modules/collection/programs/gammastep.nix
+++ b/modules/collection/programs/gammastep.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  options,
   ...
 }: let
   inherit (lib.attrsets) mapAttrs' nameValuePair;
@@ -88,7 +89,9 @@ in {
           nameValuePair "gammastep/hooks/${name}" {source = script;})
         cfg.hooks;
     }
-    (mkIf cfg.integrations.systemd.enable {
+
+    (mkIf cfg.integrations.systemd.enable (lib.optionalAttrs (options ?
+      systemd) {
       systemd.services.gammastep = {
         after = ["graphical-session.target"];
         description = "Screen color temperature manager";
@@ -100,6 +103,6 @@ in {
         };
         wantedBy = ["graphical-session.target"];
       };
-    })
+    }))
   ]);
 }

--- a/modules/collection/programs/gammastep.nix
+++ b/modules/collection/programs/gammastep.nix
@@ -1,11 +1,11 @@
 {
   config,
   lib,
-  pkgs,
   options,
+  pkgs,
   ...
 }: let
-  inherit (lib.attrsets) mapAttrs' nameValuePair;
+  inherit (lib.attrsets) mapAttrs' nameValuePair optionalAttrs;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) literalExpression mkOption mkEnableOption mkPackageOption;
@@ -89,9 +89,7 @@ in {
           nameValuePair "gammastep/hooks/${name}" {source = script;})
         cfg.hooks;
     }
-
-    (mkIf cfg.integrations.systemd.enable (lib.optionalAttrs (options ?
-      systemd) {
+    (optionalAttrs (options ? systemd) (mkIf cfg.integrations.systemd.enable {
       systemd.services.gammastep = {
         after = ["graphical-session.target"];
         description = "Screen color temperature manager";


### PR DESCRIPTION
#186 introduced the gammastep module.
This refrences a non-extistend option "systemd" on non-systemd configurations and refuses to evaluate.
```
error:
       … while calling the 'head' builtin
         at /nix/store/lcasq9wwzr5lniqj6axcj8msws5l2l2i-source/lib/attrsets.nix:1729:13:
         1728|           if length values == 1 || pred here (elemAt values 1) (head values) then
         1729|             head values
             |             ^
         1730|           else

       … while evaluating the attribute 'value'
         at /nix/store/lcasq9wwzr5lniqj6axcj8msws5l2l2i-source/lib/modules.nix:1149:7:
         1148|     // {
         1149|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1150|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `system.build.toplevel':

       … while evaluating the option `system.topLevel':

       … while evaluating definitions from `/nix/store/5ny7nlvirb6128kz1dmk8jb525clg2vh-source/modules/system/activation':

       … while evaluating the option `assertions':

       … while evaluating definitions from `/nix/store/ly70804g34vjbh42m3n6ynrlmjrflc80-source/modules/common/top-level.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: The option `hjem.users.nimeses.systemd' does not exist. Definition values:
       - In `/nix/store/36kiaigp5hfwvlyihx7drmkmbwg7ynx9-source/modules/collection/programs/gammastep.nix':
           {
             _type = "if";
             condition = false;
             content = {
               _type = "if";
           ...

       Did you mean `hjem.users.nimeses.ssh', `hjem.users.nimeses.user' or `hjem.users.nimeses.art'?
```
### Meta

[Please mention related issues if applicable]: :

Related Issue(s): None

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: Yes

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [ ] Followed the general API laid out in CONTRIBUTING.md
- [ ] Wrote tests (or expressed a need for help on tests)
