### PR TITLE
programs/password-store: init module

### DIFF
--- a/docs/manpage-urls.json
+++ b/docs/manpage-urls.json
@@ -4,5 +4,6 @@
   "tofi(5)": "https://github.com/philj56/tofi/blob/master/doc/tofi.5.md",
   "ncmpcpp(1)": "https://man.archlinux.org/man/ncmpcpp.1",
   "foot.ini(5)": "https://man.archlinux.org/man/foot.ini.5.en",
-  "IMV(5)": "https://man.archlinux.org/man/imv.5.en"
+  "IMV(5)": "https://man.archlinux.org/man/imv.5.en",
+  "pass(1)": "https://man.archlinux.org/man/pass.1.en"
 }

--- a/modules/collection/programs/password-store.nix
+++ b/modules/collection/programs/password-store.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  hjem-lib,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (hjem-lib) envVarType;
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) literalExpression mkEnableOption mkOption mkPackageOption;
+
+  cfg = config.rum.programs.password-store;
+in {
+  options.rum.programs.password-store = {
+    enable = mkEnableOption "password-store";
+
+    package = mkPackageOption pkgs "pass" {
+      nullable = true;
+      extraDescription = ''
+        To get extensions to work, you will need to wrap the pass derivation
+        with the extensions you want. Consult the [pass extensions directory]
+        for a list of available extensions.
+
+        [pass extensions directory]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/security/pass/extensions
+      '';
+      example = ''
+        pkgs.pass.withExtensions (exts: [
+          exts.pass-otp
+          exts.pass-import
+        ])
+      '';
+    };
+
+    settings = mkOption {
+      type = envVarType;
+      default = {};
+      example = literalExpression ''
+        {
+          PASSWORD_STORE_DIR = "''${config.xdg.data.directory}/password-store";
+          PASSWORD_STORE_CLIP_TIME = 60;
+        }
+      '';
+      description = ''
+        The configuration added to `environment.sessionVariables`, as
+        password-store is configured entirely through environment variables.
+        Please reference {manpage}`pass(1)` for configuration options.
+
+        These variables are only loaded by modules such as
+        {option}`rum.programs.fish.enable`. See [environmental variables] for
+        more information.
+
+        [environmental variables]: https://github.com/snugnug/hjem-rum#environmental-variables
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    packages = mkIf (cfg.package != null) [cfg.package];
+    environment.sessionVariables = cfg.settings;
+  };
+}

--- a/modules/collection/programs/password-store.nix
+++ b/modules/collection/programs/password-store.nix
@@ -31,7 +31,7 @@ in {
       '';
     };
 
-    settings = mkOption {
+    environment = mkOption {
       type = envVarType;
       default = {};
       example = literalExpression ''
@@ -56,6 +56,6 @@ in {
 
   config = mkIf cfg.enable {
     packages = mkIf (cfg.package != null) [cfg.package];
-    environment.sessionVariables = cfg.settings;
+    environment.sessionVariables = cfg.environment;
   };
 }

--- a/modules/collection/programs/password-store.nix
+++ b/modules/collection/programs/password-store.nix
@@ -3,13 +3,31 @@
   hjem-lib,
   lib,
   pkgs,
+  rumLib,
   ...
 }: let
   inherit (hjem-lib) envVarType;
+  inherit (lib.attrsets) mapAttrs' nameValuePair;
+  inherit (lib.lists) optionals;
   inherit (lib.modules) mkIf;
   inherit (lib.options) literalExpression mkEnableOption mkOption mkPackageOption;
+  inherit (lib.strings) hasPrefix;
+  inherit (rumLib.attrsets) attrNamesHasPrefix;
 
   cfg = config.rum.programs.password-store;
+
+  prefixedEnvironment =
+    mapAttrs' (
+      name: value:
+        nameValuePair
+        (
+          if hasPrefix "PASSWORD_STORE_" name
+          then name
+          else "PASSWORD_STORE_${name}"
+        )
+        value
+    )
+    cfg.environment;
 in {
   options.rum.programs.password-store = {
     enable = mkEnableOption "password-store";
@@ -36,14 +54,19 @@ in {
       default = {};
       example = literalExpression ''
         {
-          PASSWORD_STORE_DIR = "''${config.xdg.data.directory}/password-store";
-          PASSWORD_STORE_CLIP_TIME = 60;
+          DIR = "''${config.xdg.data.directory}/password-store";
+          CLIP_TIME = 60;
         }
       '';
       description = ''
         The configuration added to `environment.sessionVariables`, as
         password-store is configured entirely through environment variables.
         Please reference {manpage}`pass(1)` for configuration options.
+
+        Please note that each option name will have "PASSWORD_STORE_"
+        prepended to it, so there is no need to include that on every single
+        option. Variables outside of that namespace, such as {env}`EDITOR`,
+        should be set through {option}`environment.sessionVariables` instead.
 
         These variables are only loaded by modules such as
         {option}`rum.programs.fish.enable`. See [environmental variables] for
@@ -55,7 +78,12 @@ in {
   };
 
   config = mkIf cfg.enable {
+    # The prefix is added for the user, so simply check if they accidentally included it themselves.
+    warnings = optionals (attrNamesHasPrefix "PASSWORD_STORE_" cfg.environment) [
+      "Each option in 'rum.programs.password-store.environment' is automatically prefixed with 'PASSWORD_STORE_' if it is not present already. You have added this to an option unnecessarily."
+    ];
+
     packages = mkIf (cfg.package != null) [cfg.package];
-    environment.sessionVariables = cfg.environment;
+    environment.sessionVariables = prefixedEnvironment;
   };
 }

--- a/modules/tests/collection/programs/password-store.nix
+++ b/modules/tests/collection/programs/password-store.nix
@@ -8,7 +8,7 @@
       programs.password-store = {
         enable = true;
         package = pkgs.pass.withExtensions (exts: [exts.pass-otp]);
-        settings = {
+        environment = {
           PASSWORD_STORE_DIR = "/home/bob/.local/share/password-store";
           PASSWORD_STORE_CLIP_TIME = 60;
         };
@@ -31,7 +31,7 @@
       with subtest("Verify if the pass-otp extension is available"):
           machine.succeed("su bob -c 'pass otp --help'")
 
-      with subtest("Verify if the settings are exported"):
+      with subtest("Verify if the environment variables are exported"):
           store = machine.succeed("su bob -c \"fish -c 'echo $PASSWORD_STORE_DIR'\"").strip()
           assert store == "/home/bob/.local/share/password-store", (
               "Unexpected PASSWORD_STORE_DIR: %r" % store

--- a/modules/tests/collection/programs/password-store.nix
+++ b/modules/tests/collection/programs/password-store.nix
@@ -1,0 +1,54 @@
+{pkgs, ...}: {
+  name = "programs-password-store";
+  nodes.machine = {
+    # Needed to generate the key our store is encrypted with, as pass only exposes gpg to itself.
+    environment.systemPackages = [pkgs.gnupg];
+
+    hjem.users.bob.rum = {
+      programs.password-store = {
+        enable = true;
+        package = pkgs.pass.withExtensions (exts: [exts.pass-otp]);
+        settings = {
+          PASSWORD_STORE_DIR = "/home/bob/.local/share/password-store";
+          PASSWORD_STORE_CLIP_TIME = 60;
+        };
+      };
+
+      programs.fish.enable = true;
+    };
+  };
+
+  testScript =
+    #python
+    ''
+      # Waiting for our user to load.
+      machine.succeed("loginctl enable-linger bob")
+      machine.wait_for_unit("default.target")
+
+      with subtest("Verify if pass is in $PATH"):
+          machine.succeed("su bob -c 'which pass'")
+
+      with subtest("Verify if the pass-otp extension is available"):
+          machine.succeed("su bob -c 'pass otp --help'")
+
+      with subtest("Verify if the settings are exported"):
+          store = machine.succeed("su bob -c \"fish -c 'echo $PASSWORD_STORE_DIR'\"").strip()
+          assert store == "/home/bob/.local/share/password-store", (
+              "Unexpected PASSWORD_STORE_DIR: %r" % store
+          )
+
+          clip = machine.succeed("su bob -c \"fish -c 'echo $PASSWORD_STORE_CLIP_TIME'\"").strip()
+          assert clip == "60", "Unexpected PASSWORD_STORE_CLIP_TIME: %r" % clip
+
+      with subtest("Verify if pass is able to correctly read our config"):
+          # pass needs a key to encrypt the store with.
+          machine.succeed(
+              "su bob -c \"gpg --batch --pinentry-mode loopback --passphrase ''' "
+              "--quick-generate-key 'Bob <bob@rum.test>' default default never\""
+          )
+
+          # Our variables are loaded by fish, so pass is run through it.
+          machine.succeed("su bob -c \"fish -c 'pass init bob@rum.test'\"")
+          machine.succeed("[ -d /home/bob/.local/share/password-store ]")
+    '';
+}

--- a/modules/tests/collection/programs/password-store.nix
+++ b/modules/tests/collection/programs/password-store.nix
@@ -9,8 +9,8 @@
         enable = true;
         package = pkgs.pass.withExtensions (exts: [exts.pass-otp]);
         environment = {
-          PASSWORD_STORE_DIR = "/home/bob/.local/share/password-store";
-          PASSWORD_STORE_CLIP_TIME = 60;
+          DIR = "/home/bob/.local/share/password-store";
+          CLIP_TIME = 60;
         };
       };
 
@@ -31,14 +31,12 @@
       with subtest("Verify if the pass-otp extension is available"):
           machine.succeed("su bob -c 'pass otp --help'")
 
-      with subtest("Verify if the environment variables are exported"):
+      with subtest("Verify if the environment variables are exported and prefixed"):
           store = machine.succeed("su bob -c \"fish -c 'echo $PASSWORD_STORE_DIR'\"").strip()
-          assert store == "/home/bob/.local/share/password-store", (
-              "Unexpected PASSWORD_STORE_DIR: %r" % store
-          )
+          assert store == "/home/bob/.local/share/password-store", "PASSWORD_STORE_DIR was not set correctly"
 
           clip = machine.succeed("su bob -c \"fish -c 'echo $PASSWORD_STORE_CLIP_TIME'\"").strip()
-          assert clip == "60", "Unexpected PASSWORD_STORE_CLIP_TIME: %r" % clip
+          assert clip == "60", "PASSWORD_STORE_CLIP_TIME was not set correctly"
 
       with subtest("Verify if pass is able to correctly read our config"):
           # pass needs a key to encrypt the store with.


### PR DESCRIPTION
Adds a module for password-store (`pass`)

It's my first time contributing to hjem-rum, so any feedback is very welcome!

### Notes

- Since `pass` does not use a traditional configuration file, the module maps settings directly to environment.sessionVariables.
- Support for extensions (such as pass-otp) is handled by overriding the base package using `pkgs.pass.withExtensions`.

[This is a comment]: :

### Meta

[Please mention related issues if applicable]: :

Related Issue(s): \<None\>

[We do not currently have a policy against AI-generated code, but we ask you to disclose the usage of AI for code generation]: :

AI used to generate code included in this PR?: No

### All Submissions:

- [x] Formatted commit message in accordance with CONTRIBUTING.md guidelines
- [x] Filled in all meta items
- [x] Mentioned any blockers before the PR can merge
- [x] Verified there are no conflicting PRs open

### New Module Submissions:

- [x] Followed the general API laid out in CONTRIBUTING.md
- [x] Wrote tests (or expressed a need for help on tests)
